### PR TITLE
Disentangle matriculation data from enrich_grad_counts

### DIFF
--- a/R/grate.R
+++ b/R/grate.R
@@ -909,79 +909,21 @@ gcount_column_order <- function(df) {
 #' graduated students
 #' 
 #' @param df data frame of including subgroup percentages
+#' @param end_year numeric end year of grad counts to join
 #' 
 #' @return data_frame
 #' @export
-enrich_grad_count <- function(df) {
+enrich_grad_count <- function(df, end_year) {
   
-  if (min(df$end_year) < 2013) stop("end_year needs to be > 2012")
-  
-  grad_count_yrs <- df %>%
-    pull(end_year) %>%
-    unique()
-  
-  # need the year before the earliest year if anything earlier than
-  # 2017 is included in order to get 16 mo grad count
-  if (min(grad_count_yrs) < 2017) {
-    grad_count_yrs <- c(min(grad_count_yrs) - 1, grad_count_yrs)
-  }
-  # but there is no grad count data before 2011
-  grad_count_yrs <- grad_count_yrs[grad_count_yrs > 2011]
-  
-  grad_counts <- map(
-    grad_count_yrs, 
-    function(.x) fetch_grad_count(.x)
-  )
-  
-  grad_counts <- grad_counts %>%
-    bind_rows() %>%
-    select(-c(county_name, district_name, school_name,
-              cohort_count))
+  grad_counts <- fetch_grad_count(end_year) %>%
+    select(end_year, county_id, district_id, school_id,
+           subgroup, graduated_count, cohort_count)
     
-  postsec_rates <- data.frame(
-    end_year = 2012:2019,
-    is_16mo = c(T, T, T, T, T, F, F, F)
-    # data is from National Student Clearinghouse
-  )
-  
   out <- df %>%
-    # 16 mo matriculation rate requires 2011 grad count which we don't have
-    filter(end_year != 2012) %>%
-    left_join(postsec_rates, by = "end_year") %>%
-    mutate(gc_year = if_else(is_16mo, end_year - 1, as.numeric(end_year))) %>%
-    mutate(
-      subgroup = tolower(subgroup),
-      subgroup = case_when(
-        subgroup == "economically disadvantaged students" ~ "economically disadvantaged",
-        subgroup %in% c("english language learners",
-                        "english learners") ~ "limited english proficiency",
-        subgroup == "students with disabilities" ~ "students with disability",
-        subgroup == "two or more races" ~ "multiracial",
-        subgroup == "native hawaiian" ~ "pacific islander", # or native amer.?
-        subgroup == "american indian or alaska native" ~
-          "american indian",
-        subgroup == "asian, native hawaiian, or pacific islander" ~
-          "asian", #>=2018... what to do here?
-        TRUE ~ subgroup
-        )
-      ) %>%
-    # to do: check for subgroup consistency between grate / rc matric year by year
     left_join(grad_counts,
-              by = c("gc_year" = "end_year", "county_code" = "county_id",
-                     "district_code" = "district_id",
-                     "school_code" = "school_id", "subgroup")) %>%
-    mutate(
-      enroll_any_count = round(enroll_any / 100 * graduated_count),
-      enroll_4yr_count = round(enroll_4yr / 100 * enroll_any_count),
-      enroll_2yr_count = round(enroll_2yr / 100 * enroll_any_count)
-    ) %>%
-    # remove all the subgroup clashes -- should be fixed by the above to-do
-    filter(!is.na(is_state)) %>%
-    # each school has two rows in later years - one for the school,
-    # one as a state comparison. #144
-    group_by(end_year) %>%
-    filter(enroll_any != DescTools::Mode(enroll_any, na.rm = T)) %>%
-    ungroup()
+              by = c("end_year", "county_id",
+                     "district_id",
+                     "school_id", "subgroup"))
   
   return(out)
     

--- a/R/report_card.R
+++ b/R/report_card.R
@@ -760,6 +760,80 @@ enrich_rc_enrollment <- function(df) {
 #' 
 #' @return data_frame
 #' @export
-enrich_matric_counts <- function(df) {
+enrich_matric_counts <- function(df, type = '16 mo') {
+  if (min(df$end_year) < 2013) stop("end_year needs to be > 2012")
   
+  grad_count_yrs <- df %>%
+    pull(end_year) %>%
+    unique()
+  
+  if (type == '16 mo') {
+    
+    # 16 month matriculation requires grad counts from prior year
+    grad_count_yrs <- c((min(grad_count_yrs) - 1):(max(grad_count_yrs) - 1))
+    
+    # but there is no grad count data before 2011
+    grad_count_yrs <- grad_count_yrs[grad_count_yrs > 2011]
+    
+    postsec_rates <- data.frame(
+      end_year = 2012:2019,
+      is_16mo = rep(T, 8)
+    )
+  } else if (type == '12 mo') {
+    postsec_rates <- data.frame(
+    end_year = 2017:2019,
+    is_16mo = rep(F, 3)
+    )
+  } else {
+    stop("type should be one of {\'16 mo\' or \'12 mo\'}")
+  }
+  
+  
+  # prepare matric df to join grad count
+  df <- df %>%
+    # 2012 rc reports only 16 month matriculation rates, which would
+    # require 2011 grad counts, which are not available
+    filter(end_year != 2012) %>%
+    left_join(postsec_rates, by = "end_year") %>%
+    # 16 month matriculation rates requires last year's grad counts
+    mutate(orig_end_year = end_year,
+           end_year = if_else(is_16mo, end_year - 1, as.numeric(end_year))) %>%
+    mutate(
+      subgroup = tolower(subgroup),
+      subgroup = case_when(
+        subgroup == "economically disadvantaged students" ~ "economically disadvantaged",
+        subgroup %in% c("english language learners",
+                        "english learners") ~ "limited english proficiency",
+        subgroup == "students with disabilities" ~ "students with disability",
+        subgroup == "two or more races" ~ "multiracial",
+        subgroup == "native hawaiian" ~ "pacific islander", # or native amer.?
+        subgroup == "american indian or alaska native" ~
+          "american indian",
+        subgroup == "asian, native hawaiian, or pacific islander" ~
+          "asian", #>=2018... what to do here?
+        TRUE ~ subgroup
+      )
+    ) %>%
+    rename(county_id = county_code, 
+           district_id = district_code,
+           school_id = school_code)
+  
+  matric_by_yr <- split(df, df$end_year)
+  
+  
+  out <- map_dfr(
+    matric_by_yr, 
+    function(.x) enrich_grad_count(.x, unique(.x$end_year))
+    ) %>%
+    # restore original end year
+    select(-end_year) %>%
+    rename(end_year = orig_end_year) %>%
+    distinct(.keep_all = T) %>%
+    mutate(
+      enroll_any_count = round(enroll_any / 100 * graduated_count),
+      enroll_4yr_count = round(enroll_4yr / 100 * enroll_any_count),
+      enroll_2yr_count = round(enroll_2yr / 100 * enroll_any_count)
+    )
+  
+  return(out)
 }

--- a/R/report_card.R
+++ b/R/report_card.R
@@ -751,3 +751,15 @@ enrich_rc_enrollment <- function(df) {
   
   return(df)
 }
+
+
+
+#' Enrich matriculation rates with counts from grad counts
+#' 
+#' @param df data frame of including matriculation percentages
+#' 
+#' @return data_frame
+#' @export
+enrich_matric_counts <- function(df) {
+  
+}

--- a/R/report_card.R
+++ b/R/report_card.R
@@ -760,14 +760,14 @@ enrich_rc_enrollment <- function(df) {
 #' 
 #' @return data_frame
 #' @export
-enrich_matric_counts <- function(df, type = '16 mo') {
+enrich_matric_counts <- function(df, type = '16 month') {
   if (min(df$end_year) < 2013) stop("end_year needs to be > 2012")
   
   grad_count_yrs <- df %>%
     pull(end_year) %>%
     unique()
   
-  if (type == '16 mo') {
+  if (type == '16 month') {
     
     # 16 month matriculation requires grad counts from prior year
     grad_count_yrs <- c((min(grad_count_yrs) - 1):(max(grad_count_yrs) - 1))
@@ -779,13 +779,13 @@ enrich_matric_counts <- function(df, type = '16 mo') {
       end_year = 2012:2019,
       is_16mo = rep(T, 8)
     )
-  } else if (type == '12 mo') {
+  } else if (type == '12 month') {
     postsec_rates <- data.frame(
     end_year = 2017:2019,
     is_16mo = rep(F, 3)
     )
   } else {
-    stop("type should be one of {\'16 mo\' or \'12 mo\'}")
+    stop("type should be one of {\'16 month\' or \'12 month\'}")
   }
   
   

--- a/tests/testthat/test_grate.R
+++ b/tests/testthat/test_grate.R
@@ -201,3 +201,16 @@ test_that("ground truth values on 2019 grad count", {
 })
 
 
+test_that("grad counts correctly enriched", {
+  grate_19 <- fetch_grad_rate(2019)
+  
+  ex <- enrich_grad_count(grate_19, 2019)
+  
+  ex_row <- ex %>%
+    filter(district_id == '3570',
+           school_id == '055',
+           subgroup == 'total population')
+  
+  expect_equal(pull(ex_row, graduated_count.x),
+               pull(ex_row, graduated_count.y))
+  })

--- a/tests/testthat/test_report_card.R
+++ b/tests/testthat/test_report_card.R
@@ -185,29 +185,39 @@ test_that("enrich_grad_count joins correct subgroup", {
   gc_12 <- fetch_grad_count(2012)
   
   matric_counts_13 <- matric_13 %>%
-    enrich_grad_count()
+    enrich_matric_counts()
   
   expect_equal(matric_counts_13 %>%
-                 filter(district_code == '3570',
-                        school_code == '055',
+                 filter(district_id == '3570',
+                        school_id == '055',
                         subgroup == 'black') %>%
                  pull(graduated_count),
                62)
   
   expect_equal(matric_counts_13 %>%
-                 filter(district_code == '3570',
-                        school_code == '055',
+                 filter(district_id == '3570',
+                        school_id == '055',
                         subgroup == 'economically disadvantaged') %>%
                  pull(graduated_count),
                128)
 })
 
 
-test_that("enrich_grad_count gets both 12/16 mo", {
+test_that("12/16 mo matriculation rates can be extracted", {
   
   matric_18 <- extract_rc_college_matric(list(rc_2018))
   matric_18_12mo <- extract_rc_college_matric(list(rc_2018),
                                               type = '12 month')
   
   expect_false(identical(matric_18, matric_18_12mo))
+})
+
+
+test_that("enrich_matriculation_counts works over multiple years", {
+  
+  matric_16_17_18 <- extract_rc_college_matric(list(rc_2016, rc_2017, rc_2018))
+  
+  matric_counts_16_17_18 <- enrich_matric_counts(matric_16_17_18)
+  
+  expect_is(matric_counts_16_17_18, "data.frame")
 })

--- a/tests/testthat/test_report_card.R
+++ b/tests/testthat/test_report_card.R
@@ -142,47 +142,72 @@ test_that("extract_rc_college_matric ground truth values", {
                93.6)
 })
 
-test_that("enrich_grad_count joins correct years", {
+test_that("enrich_matric_counts joins correct years", {
   matric_12 <- extract_rc_college_matric(list(rc_2012))
   
   expect_error(matric_12 %>%
                  enrich_grad_count())
   
   
+  gcount_12 <- fetch_grad_count(2012)
   matric_13 <- extract_rc_college_matric(list(rc_2013))
   
   matric_counts_13 <- matric_13 %>%
-    enrich_grad_count()
+    enrich_matric_counts()
+  
   
   expect_equal(matric_counts_13 %>%
-                 pull(gc_year) %>%
-                 unique(),
-               unique(matric_counts_13$end_year) - 1)
-  
-  expect_equal(matric_counts_13 %>%
-                 filter(district_code == '3570',
-                        school_code == '055',
+                 filter(district_id == '3570',
+                        school_id == '055',
                         subgroup == 'total population') %>%
                  pull(graduated_count),
-               167)
+               gcount_12 %>%
+                 filter(district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'total population') %>%
+                 pull(graduated_count))
+
   
   
-  matric_17 <- extract_rc_college_matric(list(rc_2017))
+  matric_18 <- extract_rc_college_matric(list(rc_2018))
+  matric_18_12mo <- extract_rc_college_matric(list(rc_2018),
+                                              type = "12 month")
+  gcount_17 <- fetch_grad_count(2017)
+  gcount_18 <- fetch_grad_count(2018)
   
-  matric_counts_17 <- matric_17 %>%
-    enrich_grad_count()
+  matric_counts_18 <- matric_18 %>%
+    enrich_matric_counts()
+  matric_counts_18_12mo <- matric_18_12mo %>%
+    enrich_matric_counts(type = "12 month")
   
-  expect_equal(matric_counts_17 %>%
-                 pull(gc_year) %>%
-                 unique(),
-               unique(matric_counts_17$end_year))
+  expect_equal(matric_counts_18 %>%
+                 filter(district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'total population') %>%
+                 pull(graduated_count),
+               gcount_17 %>%
+                 filter(district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'total population') %>%
+                 pull(graduated_count))
+  
+  expect_equal(matric_counts_18_12mo %>%
+                 filter(district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'total population') %>%
+                 pull(graduated_count),
+               gcount_18 %>%
+                 filter(district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'total population') %>%
+                 pull(graduated_count))
 })
 
 test_that("enrich_grad_count joins correct subgroup", {
 
   matric_13 <- extract_rc_college_matric(list(rc_2013))
   
-  gc_12 <- fetch_grad_count(2012)
+  gcount_12 <- fetch_grad_count(2012)
   
   matric_counts_13 <- matric_13 %>%
     enrich_matric_counts()
@@ -192,32 +217,63 @@ test_that("enrich_grad_count joins correct subgroup", {
                         school_id == '055',
                         subgroup == 'black') %>%
                  pull(graduated_count),
-               62)
+               gcount_12 %>%
+                 filter(district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'black') %>%
+                 pull(graduated_count))
   
   expect_equal(matric_counts_13 %>%
                  filter(district_id == '3570',
                         school_id == '055',
                         subgroup == 'economically disadvantaged') %>%
                  pull(graduated_count),
-               128)
+               gcount_12 %>%
+                 filter(district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'economically disadvantaged') %>%
+                 pull(graduated_count))
 })
 
 
-test_that("12/16 mo matriculation rates can be extracted", {
-  
-  matric_18 <- extract_rc_college_matric(list(rc_2018))
-  matric_18_12mo <- extract_rc_college_matric(list(rc_2018),
-                                              type = '12 month')
-  
-  expect_false(identical(matric_18, matric_18_12mo))
-})
 
-
-test_that("enrich_matriculation_counts works over multiple years", {
+test_that("enrich_matric_counts enriches multiple yrs", {
+  matric_1819 <- extract_rc_college_matric(list(rc_2018, rc_2019))
   
-  matric_16_17_18 <- extract_rc_college_matric(list(rc_2016, rc_2017, rc_2018))
+  matric_counts_18 <- rc_2018 %>%
+    list() %>%
+    extract_rc_college_matric() %>%
+    enrich_matric_counts()
   
-  matric_counts_16_17_18 <- enrich_matric_counts(matric_16_17_18)
+  matric_counts_17 <- rc_2017 %>%
+    list() %>%
+    extract_rc_college_matric() %>%
+    enrich_matric_counts()
   
-  expect_is(matric_counts_16_17_18, "data.frame")
+  matric_counts_1819 <- matric_1819 %>%
+    enrich_matric_counts()
+  
+  expect_equal(matric_counts_1819 %>%
+                 filter(end_year == 2019,
+                        district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'black') %>%
+                 pull(graduated_count),
+               gcount_18 %>% 
+                 filter(district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'black') %>%
+                 pull(graduated_count))
+  
+  expect_equal(matric_counts_1819 %>%
+                 filter(end_year == 2018,
+                        district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'hispanic') %>%
+                 pull(graduated_count),
+               gcount_17 %>% 
+                 filter(district_id == '3570',
+                        school_id == '055',
+                        subgroup == 'hispanic') %>%
+                 pull(graduated_count))
 })


### PR DESCRIPTION
## proposed changes
- rewrite `enrich_grad_count()` to enrich a df with grad counts for a given year
- write `enrich_matric_counts()` to take care of mismatch years (i.e. 2015 matriculation rates are 16 mo. rates and use 2014 grad counts) and enable multi-year dfs

## test
`testthat::test_file("tests/testthat/test_report_card.R")`
`testthat::test_file("tests/testthat/test_grate.R")`