### PR TITLE
Add No-PK enrollment grades aggregate

### DIFF
--- a/R/enr.R
+++ b/R/enr.R
@@ -726,6 +726,25 @@ enr_grade_aggs <- function(df) {
     ) %>%
     gr_aggs_col_order()
   
+  # All but PK enrollment
+  nopk_agg <- df %>%
+    filter(
+      grade_level %in% c('K', 
+                         '01', '02', '03', '04',
+                         '05', '06', '07', '08',
+                         '09', '10', '11', '12') |
+        program_code == 'UG'
+    ) %>%
+    gr_aggs_group_logic() %>%
+    mutate(
+      program_code = 'K12UG',
+      program_name = 'K to 12 Total, UG inclusive',
+      grade_level = 'K12UG',
+      pct = NA_real_,
+      pct_total_enr = NA_real_
+    ) %>%
+    gr_aggs_col_order()
+  
   # K-8 enrollment
   k8_agg <- df %>%
     filter(
@@ -758,7 +777,7 @@ enr_grade_aggs <- function(df) {
     ) %>%
     gr_aggs_col_order()
   
-  bind_rows(pk_agg, k_agg, k12_agg, k8_agg, hs_agg)
+  bind_rows(pk_agg, k_agg, k12_agg, nopk_agg, k8_agg, hs_agg)
 }
 
 #' @title gets and processes a NJ enrollment file

--- a/tests/testthat/test_enr.R
+++ b/tests/testthat/test_enr.R
@@ -310,6 +310,21 @@ test_that("enr_grade_aggs works", {
     filter(district_id == '3570' & school_id == '310' & grade_level=='K8')
   expect_equal(camden_es_k8$n_students, camden_es_k12$n_students)
   
+  expect_gte(
+    aggs_2018 %>%
+      filter(district_id == '3570',
+             school_id == '020',
+             grade_level == 'K12UG',
+             subgroup == 'total_enrollment') %>%
+      pull(n_students),
+    aggs_2018 %>%
+      filter(district_id == '3570',
+             school_id == '020',
+             grade_level == 'K12',
+             subgroup == 'total_enrollment') %>%
+      pull(n_students)
+    )
+  
 })
 
 test_that("frl group exists", {


### PR DESCRIPTION
An easy one here -- it's the same code as the K-12 aggregate but includes `program_code == 'UG` as an or in the filtering logic. The aggregated program code is `K12UG`, which I'm not terribly wedded to... `NOPK`?

testthat::test_file("tests/testthat/test_enr.R")