### PR TITLE
Resolve duplicate district mSGPs in 2016

### DIFF
--- a/R/msgp.R
+++ b/R/msgp.R
@@ -122,20 +122,35 @@ get_and_process_msgp <- function(end_year) {
         is_district = FALSE
       )
     
+    # identify high schools by their presence in PR grad rate table
+    high_school_cds <- df_list$grad_rate_by_subgroup %>%
+      mutate(cds = paste0(county_code, district_code, school_code)) %>%
+      pull(cds)
+    
     df_district <- df_sgp %>%
-      select(county_code, district_code, student_growth, district_median, end_year) %>%
+      select(county_code, district_code, school_code, 
+             student_growth, district_median, end_year) %>%
+      # use cds in grad rate table to filter out high schools
+      filter(!paste0(county_code, district_code, school_code) %in% high_school_cds) %>%
       rename(
         subject = student_growth,
         median_sgp = district_median
       ) %>%
-      unique() %>%
       mutate(
         school_code = '999',
         grade = 'TOTAL',
         subgroup = 'total population',
         is_school = FALSE,
         is_district = TRUE
-      )
+      ) %>%
+      # assume majority of high schools have been filtered out; mode of 
+      # median_sgp should return the elem value
+      # checked: after filtering using cds, two districts are left with
+      # multiple msgp values: 3570 (of course... *eye roll*) and 5850. 
+      # 5850 only has one school with 'S' as msgp value and 3570 has eagle
+      # and state school id 311 with presumably high school values
+      filter(median_sgp == DescTools::Mode(median_sgp)) %>%
+      unique()
     
     out <- bind_rows(df_school, df_district) %>%
       select(

--- a/tests/testthat/test_msgp.R
+++ b/tests/testthat/test_msgp.R
@@ -15,6 +15,13 @@ test_that("sgp works with 2016 data", {
       "end_year", "subject", "grade", "subgroup", "median_sgp", 
       "is_district", "is_school")
   )
+  
+  expect_length(sgp16 %>%
+                  filter(is_district) %>%
+                  group_by(district_id, subject) %>%
+                  filter(n() > 1) %>%
+                  pull(median_sgp) %>%
+                  0)
 })
 
 


### PR DESCRIPTION
## proposed changes
- remove district mSGPs associated with high schools in 2016
   - use grad rate table to identify high schools' cds codes
   - mode of the remaining mSGPs should return the elementary value

## test
`testthat::test_file("tests/testthat/test_msgp.R")`