### PR TITLE
Fix 2016 district mSGP

### DIFF
--- a/R/msgp.R
+++ b/R/msgp.R
@@ -143,6 +143,7 @@ get_and_process_msgp <- function(end_year) {
         is_school = FALSE,
         is_district = TRUE
       ) %>%
+      group_by(district_code, subject) %>%
       # assume majority of high schools have been filtered out; mode of 
       # median_sgp should return the elem value
       # checked: after filtering using cds, two districts are left with
@@ -150,6 +151,7 @@ get_and_process_msgp <- function(end_year) {
       # 5850 only has one school with 'S' as msgp value and 3570 has eagle
       # and state school id 311 with presumably high school values
       filter(median_sgp == DescTools::Mode(median_sgp)) %>%
+      ungroup() %>%
       unique()
     
     out <- bind_rows(df_school, df_district) %>%

--- a/tests/testthat/test_msgp.R
+++ b/tests/testthat/test_msgp.R
@@ -20,8 +20,14 @@ test_that("sgp works with 2016 data", {
                   filter(is_district) %>%
                   group_by(district_id, subject) %>%
                   filter(n() > 1) %>%
-                  pull(median_sgp) %>%
+                  pull(median_sgp),
                   0)
+  
+  expect_length(sgp16 %>%
+                  filter(district_id == '3570',
+                         is_district) %>%
+                  pull(median_sgp), 
+                2)
 })
 
 


### PR DESCRIPTION
Wrote bad tests for the first PR on this topic...

Filtering by mode in 2016 mSGP is only done *after* grouping by district and subject; wrote a test to make sure 3570 has two mSGP values.