### PR TITLE
School name lookup collision

### DIFF
--- a/R/lookups.R
+++ b/R/lookups.R
@@ -65,7 +65,7 @@ district_name_to_id <- function(district_names, df) {
 friendly_school_names <- function(df) {
   # group by district id, tag by most recent year in df, take first
   df_first <- df %>% 
-    group_by(school_id) %>% 
+    group_by(district_id, school_id) %>% 
     arrange(-end_year) %>%
     mutate(count = row_number()) %>%
     ungroup() %>%

--- a/tests/testthat/test_lookups.R
+++ b/tests/testthat/test_lookups.R
@@ -25,3 +25,18 @@ test_that("district_name_to_id correctly identifies the friendly names", {
     c("6010", "0010", "0020", "6032", "6110")
   )
 })
+
+
+test_that("comparing schools with the same id across districts", {
+  
+  newark <- filter(enr_several, district_id %in% c('3570')) %>%
+    friendly_school_names()
+  
+  jerseycity <- filter(enr_several, district_id %in% c('2390')) %>%
+    friendly_school_names()
+  
+  both <- filter(enr_several, district_id %in% c('3570', '2390')) %>%
+    friendly_school_names()
+  
+  expect_equal(length(both), length(newark) + length(jerseycity))
+})


### PR DESCRIPTION
If multiple districts with overlapping `school_id`s are the input of `friendly_school_names()`, only one corresponding school name is returned. this is fixed here by grouping by district_id and school_id and can be tested with testthat::test_file("tests/testthat/test_lookup.R")