### PR TITLE
refactor enr pulls to work with 2021 data

### DIFF
--- a/tests/testthat/test_enr.R
+++ b/tests/testthat/test_enr.R
@@ -385,7 +385,33 @@ test_that("2020 isn't terribly wrong", {
                       subgroup == "migrant") %>%
                  pull(n_students),
                0)
+})
+
+
+test_that("2021 makes sense", {
+  enr_2021 <- fetch_enr(2021, tidy = TRUE)
   
-  
-  
+  expect_equal(filter(enr_2021,
+                      district_id == '3570',
+                      school_id == '999',
+                      grade_level == "TOTAL",
+                      subgroup == "total_enrollment") %>%
+                 pull(n_students),
+               36405)
+
+  expect_equal(filter(enr_2021,
+                      district_id == '3570',
+                      school_id == '303',
+                      grade_level == "01",
+                      subgroup == "total_enrollment") %>%
+                 pull(n_students),
+               82)
+
+  expect_equal(filter(enr_2021,
+                      district_id == '3570',
+                      school_id == '004',
+                      program_code == "55",
+                      subgroup == "migrant") %>%
+                 pull(n_students),
+               0)
 })


### PR DESCRIPTION
## description of the change

changes made in 2020 look to be permanent, so did some refactoring to separate general '2020-onward' stuff from 'weird 2020 mistakes'

## how to test
`test_file('tests/testthat/test_enr.R')` should return zero failures
`[ FAIL 0 | WARN 6 | SKIP 0 | PASS 97 ]` locally

(warnings appear to mostly be badly formatted 1999 csv files)
