### PR TITLE
Fixed grate functions 

### DIFF
--- a/R/grate.R
+++ b/R/grate.R
@@ -47,17 +47,21 @@ process_grate <- function(df, end_year) {
   names(df)[names(df) %in% c('2/MORE_RACES_M(NON_HISP)', '2_MORE_M')] <- 'multiracial_m'
   names(df)[names(df) %in% c('2/MORE_RACES_F(NON_HISP)', '2_MORE_F')] <- 'multiracial_f'
 
-  names(df)[names(df) %in% c('SUBGROUP', 'Subgroup')] <- 'group'
+  names(df)[names(df) %in% c('SUBGROUP', 'Subgroup', "Student Group")] <- 'group'
   names(df)[names(df) %in% c(
     'Four Year Graduation Rate',
     '2011 Adjusted Cohort Grad Rate',
     '2012 Adjusted Cohort Grad Rate',
-    'FOUR_YR_GRAD_RATE'
+    'FOUR_YR_GRAD_RATE',
+    'Graduation Rate'
   )] <- 'grad_rate'
   names(df)[names(df) %in% c('Four Year Adjusted Cohort Count', 'FOUR_YR_ADJ_COHORT_COUNT')] <- 'cohort_count'
   names(df)[names(df) %in% c('Four Year Graduates Count', 'GRADUATED_COUNT')] <- 'graduated_count'
 
   names(df) <- names(df) %>% tolower()
+
+
+
 
   numeric_cols <- c("rowtotal", "female", "male",
     "white", "black", "hispanic", "native_american",
@@ -351,7 +355,8 @@ tidy_grad_rate <- function(df, end_year, methodology = '4 year') {
 
     out <- dplyr::rbind_all(sch_list)
   #cohort 2011-2012 didn't report subgroups method (different file structure)
-  } else if (end_year %in%  c(2011, 2012)) {
+  #cohort 2020 lacks cohortcount and graduated_count columns . . . . yeah!
+  } else if (end_year %in%  c(2011, 2012, 2020)) {
     out <- tidy_new_format(df)
   #2013 shifted to long format
   } else if (end_year >= 2013) {
@@ -414,7 +419,7 @@ grad_file_group_cleanup <- function(group) {
 
 get_raw_grad_file <- function(end_year, methodology = '4 year') {
 
-  if (end_year < 1998 | end_year > 2019) {
+  if (end_year < 1998 | end_year > 2021) {
     stop('year not yet supported')
   }
 
@@ -447,35 +452,54 @@ get_raw_grad_file <- function(end_year, methodology = '4 year') {
 
       # 2012 they transition the format but post it in a weird location
       } else if (end_year == 2012) {
-         grate_url <- 'https://www.state.nj.us/education/data/grate/2012/grd.xls'
+         grate_url <- 'https://www.nj.gov/education/schoolperformance/grad/data/ACGR2012_grd.xls'
          grate_file <- tempfile(fileext = ".xls")
          httr::GET(url = grate_url, httr::write_disk(grate_file))
          df <- readxl::read_excel(grate_file)
 
       # 2013 on is the cohort grad rate era
-      } else if (end_year >= 2013 & end_year <= 2018) {
+      } else if (end_year >= 2013 & end_year <= 2017) {
          #build url
-         basic_suffix <- "/4Year.xlsx"
+         basic_suffix <- "_4Year.xlsx"
          num_skip <- 0
 
-         if (end_year >= 2018) {
-            basic_suffix <- "/4YearGraduation.xlsx"
-            num_skip <- 3
-         }
+         # if (end_year >= 2018) {
+         #    basic_suffix <- "/4YearGraduation.xlsx"
+         #    num_skip <- 3
+         # }
 
-         grate_url <- paste0("http://www.state.nj.us/education/data/grate/", end_year, basic_suffix)
+         grate_url <- paste0("https://www.nj.gov/education/schoolperformance/grad/data/ACGR", end_year, basic_suffix)
          grate_file <- tempfile(fileext = ".xlsx")
          httr::GET(url = grate_url, httr::write_disk(grate_file))
          df <- readxl::read_excel(grate_file, skip = num_skip)
 
-      } else { # if year == 2019
+
+
+      # starting in 2018 the URLS are inconsistent, so better, for now to hard code them
+      } else if (end_year == 2018) {
+        # new location!
+        grate_url <- "https://www.nj.gov/education/schoolperformance/grad/data/ACGR2018_4YearGraduation.xlsx"
+        num_skip <- 3
+        grate_file <- tempfile(fileext = ".xlsx")
+        httr::GET(url = grate_url, httr::write_disk(grate_file))
+        df <- readxl::read_excel(grate_file, skip = num_skip)
+
+
+      } else if (end_year == 2019) {
          # new location!
          grate_url <- "https://www.nj.gov/education/schoolperformance/grad/data/ACGR2019_Cohort%202019%204-Year%20Adjusted%20Cohort%20Graduation%20Rates%20by%20Student%20Group.xlsx"
          num_skip <- 3
          grate_file <- tempfile(fileext = ".xlsx")
          httr::GET(url = grate_url, httr::write_disk(grate_file))
          df <- readxl::read_excel(grate_file, skip = num_skip)
-      }
+
+      } else if (end_year == 2020) {
+        grate_url <- "https://www.nj.gov/education/schoolperformance/grad/data/Cohort%202020%204-Year%20Adjusted%20Cohort%20Graduation%20Rates%20by%20Student%20Group.xlsx"
+        num_skip  <- 3
+        grate_file <- tempfile(fileext = ".xlsx")
+        httr::GET(url = grate_url, httr::write_disk(grate_file))
+        df <- readxl::read_excel(grate_file, skip = num_skip)
+        }
 
    ########## 5 year ##########
    } else if (methodology == '5 year') {
@@ -506,10 +530,14 @@ get_raw_grad_file <- function(end_year, methodology = '4 year') {
          )
          num_skip <- 3
 
-      } else { # if (end_year == 2018) {
+      } else if (end_year == 2018) {
          grate_url <- "https://www.nj.gov/education/schoolperformance/grad/data/ACGR2019_Cohort%202018%204-Year%20and%205-Year%20Adjusted%20Cohort%20Graduation%20Rates.xlsx"
          num_skip <- 3
-      }
+
+      } else if (end_year == 2019){
+        grate_url <- "https://www.nj.gov/education/schoolperformance/grad/data/Cohort%202019%204-Year%20and%205-Year%20Adjusted%20Cohort%20Graduation%20Rates.xlsx"
+        num_skip <- 3
+        }
 
       grate_file <- tempfile(fileext = ".xlsx")
       httr::GET(url = grate_url, httr::write_disk(grate_file))
@@ -780,7 +808,7 @@ fetch_grad_count <- function(end_year) {
 #' @export
 
 get_grad_rate <- function(end_year, methodology) {
-  if (end_year < 2011 | end_year > 2019) {
+  if (end_year < 2011 | end_year > 2021) {
     stop('year not yet supported')
   }
 
@@ -905,27 +933,27 @@ gcount_column_order <- function(df) {
 }
 
 
-#' Enrich report card matriculation percentages with best guesses at 
+#' Enrich report card matriculation percentages with best guesses at
 #' graduated students
-#' 
+#'
 #' @param df data frame of including subgroup percentages
 #' @param end_year numeric end year of grad counts to join
-#' 
+#'
 #' @return data_frame
 #' @export
 enrich_grad_count <- function(df, end_year) {
-  
+
   grad_counts <- fetch_grad_count(end_year) %>%
     select(end_year, county_id, district_id, school_id,
            subgroup, graduated_count, cohort_count)
-    
+
   out <- df %>%
     left_join(grad_counts,
               by = c("end_year", "county_id",
                      "district_id",
                      "school_id", "subgroup"))
-  
+
   return(out)
-    
+
 }
 

--- a/R/grate.R
+++ b/R/grate.R
@@ -313,7 +313,8 @@ tidy_grad_rate <- function(df, end_year, methodology = '4 year') {
       "cohort 2015 5 year graduation rate",
       "cohort 2016 5 year graduation rate",
       'class of 2017 5-year graduation rate',
-      "cohort 2018 5-year graduation rate"
+      "cohort 2018 5-year graduation rate",
+      "cohort 2019 5-year graduation rate"
     )] <- 'grad_rate'
 
     if (class(df$grad_rate) == "character") {
@@ -359,7 +360,7 @@ tidy_grad_rate <- function(df, end_year, methodology = '4 year') {
   } else if (end_year %in%  c(2011, 2012, 2020)) {
     out <- tidy_new_format(df)
   #2013 shifted to long format
-  } else if (end_year >= 2013) {
+  } else if (end_year > 2012) {
     # 5 year doesn't have group
     if (methodology == '5 year') {
       df <- tidy_new_format(df)
@@ -369,7 +370,7 @@ tidy_grad_rate <- function(df, end_year, methodology = '4 year') {
     out <- df
   }
 
-  # 2018 and 2019 silly row
+  # 2018 and 2019 and 2020 silly row
   out <- out %>% filter(!county_id == 'end of worksheet')
 
   out$group <- grad_file_group_cleanup(out$group)
@@ -507,27 +508,29 @@ get_raw_grad_file <- function(end_year, methodology = '4 year') {
       if (end_year < 2012) {
          stop(paste0('5 year grad rate not available for ending year ', end_year))
 
-      }  else if (end_year <= 2014) {
-         #build url
-         grate_url <- paste0(
-            "http://www.state.nj.us/education/data/grate/", end_year + 1,
-            "/4And5YearCohort", substr(end_year, 3, 4), ".xlsx"
-         )
-         num_skip <- 0
+      }  else if (end_year == 2012) {
+        grate_url <- 'https://www.nj.gov/education/schoolperformance/grad/data/ACGR2013_4And5YearCohort12.xlsx'
+        num_skip <- 0
+
+
+      }  else if (end_year == 2013) {
+        grate_url <- 'https://www.nj.gov/education/schoolperformance/grad/data/ACGR2014_4And5YearCohort13.xlsx'
+        num_skip <- 0
+
+      }  else if (end_year == 2014) {
+        grate_url <- 'https://www.nj.gov/education/schoolperformance/grad/data/ACGR2015_4And5YearCohort14.xlsx'
+        num_skip <- 0
 
       } else if (end_year == 2015) {
-         grate_url <- 'https://www.state.nj.us/education/data/grate/2016/4And5YearCohort14.xlsx'
+         grate_url <- 'https://www.nj.gov/education/schoolperformance/grad/data/ACGR2016_4And5YearCohort14.xlsx'
          num_skip <- 0
 
       } else if (end_year == 2016) {
-         grate_url <- 'https://www.state.nj.us/education/data/grate/2017/4And5YearCohort.xlsx'
+         grate_url <- "https://www.nj.gov/education/schoolperformance/grad/data/ACGR2017_4And5YearCohort.xlsx"
          num_skip <- 0
 
       } else if (end_year == 2017) {
-         grate_url <- paste0(
-            "http://www.state.nj.us/education/data/grate/", end_year + 1,
-            "/4and5YearGraduationRates.xlsx"
-         )
+         grate_url <- "https://www.nj.gov/education/schoolperformance/grad/data/ACGR2018_4and5YearGraduationRates.xlsx"
          num_skip <- 3
 
       } else if (end_year == 2018) {
@@ -537,7 +540,8 @@ get_raw_grad_file <- function(end_year, methodology = '4 year') {
       } else if (end_year == 2019){
         grate_url <- "https://www.nj.gov/education/schoolperformance/grad/data/Cohort%202019%204-Year%20and%205-Year%20Adjusted%20Cohort%20Graduation%20Rates.xlsx"
         num_skip <- 3
-        }
+
+      }
 
       grate_file <- tempfile(fileext = ".xlsx")
       httr::GET(url = grate_url, httr::write_disk(grate_file))

--- a/R/grate.R
+++ b/R/grate.R
@@ -76,7 +76,13 @@ process_grate <- function(df, end_year) {
 
   for (i in numeric_cols) {
     if (i %in% names(df)) {
-      df[, i] <- df %>% dplyr::pull(i) %>% as.numeric()
+      df <- df %>%
+        dplyr::mutate({{i}} := as.numeric(
+                            dplyr::if_else(stringr::str_detect(.data[[i]], "\\*|N|-"),
+                                           NA_character_,
+                                           .data[[i]])
+                                      )
+                      )
     }
   }
 
@@ -318,7 +324,18 @@ tidy_grad_rate <- function(df, end_year, methodology = '4 year') {
     )] <- 'grad_rate'
 
     if (class(df$grad_rate) == "character") {
-       df$grad_rate <- as.numeric(df$grad_rate) / 100
+
+      df <- df %>%  dplyr::mutate(grad_rate =
+                             as.numeric(
+                               dplyr::if_else(stringr::str_detect(grad_rate, "\\*|N|-"),
+                                              NA_character_,
+                                              grad_rate)
+                               ),
+                             grad_rate = grad_rate / 100
+                             )
+
+
+       #df$grad_rate <- df$grad_rate / 100
     }
 
     if (!'cohort_count' %in% names(df)) {

--- a/tests/testthat/test_grate.R
+++ b/tests/testthat/test_grate.R
@@ -24,6 +24,7 @@ test_that('fetch_grad_rate works with 4 year', {
    ex5 <- fetch_grad_rate(2017, '4 year')
    ex6 <- fetch_grad_rate(2018, '4 year')
    ex7 <- fetch_grad_rate(2019, '4 year')
+   ex8 <- fetch_grad_rate(2020, '4 year')
 
    expect_is(ex0, 'data.frame')
    expect_is(ex1, 'data.frame')
@@ -33,12 +34,14 @@ test_that('fetch_grad_rate works with 4 year', {
    expect_is(ex5, 'data.frame')
    expect_is(ex6, 'data.frame')
    expect_is(ex7, 'data.frame')
+   expect_is(ex8, 'data.frame')
 })
 
 test_that('fetch_grad_rate all years', {
 
    expect_error(fetch_grad_rate(2010))
-   grr12 <- fetch_grad_rate(2011)
+   expect_error(fetch_grad_rate(2011))
+   #grr12 <- fetch_grad_rate(2011)
    grr13 <- fetch_grad_rate(2012)
    grr14 <- fetch_grad_rate(2013)
    grr15 <- fetch_grad_rate(2014)
@@ -47,7 +50,8 @@ test_that('fetch_grad_rate all years', {
    grr18 <- fetch_grad_rate(2017)
    grr19 <- fetch_grad_rate(2018)
    grr20 <- fetch_grad_rate(2019)
-   expect_error(fetch_grad_rate(2020))
+   grr20 <- fetch_grad_rate(2020)
+   expect_error(fetch_grad_rate(2021))
 
 })
 
@@ -203,14 +207,14 @@ test_that("ground truth values on 2019 grad count", {
 
 test_that("grad counts correctly enriched", {
   grate_19 <- fetch_grad_rate(2019)
-  
+
   ex <- enrich_grad_count(grate_19, 2019)
-  
+
   ex_row <- ex %>%
     filter(district_id == '3570',
            school_id == '055',
            subgroup == 'total population')
-  
+
   expect_equal(pull(ex_row, graduated_count.x),
                pull(ex_row, graduated_count.y))
   })

--- a/tests/testthat/test_grate.R
+++ b/tests/testthat/test_grate.R
@@ -95,6 +95,30 @@ test_that("ground truth values on 2019 grate", {
 })
 
 
+test_that("ground truth values on 2020 grate", {
+  ex <- fetch_grad_rate(2020)
+  expect_is(ex, "data.frame")
+  expect_equal(names(ex), grad_rate_cols)
+
+  expect_equal(filter(ex,
+                      district_id == '3570',
+                      school_id == '030',
+                      subgroup == 'black') %>%
+                 pull(grad_rate), 0.754)
+
+  expect_equal(filter(ex,
+                      district_id == '3570',
+                      school_id == '030',
+                      subgroup == 'white') %>%
+                 pull(grad_rate), NA_real_)
+
+  expect_equal(filter(ex,
+                      district_id == '3570',
+                      school_id == '030',
+                      subgroup == 'students with disability') %>%
+                 pull(grad_rate), 0.672)
+})
+
 
 ## 5 year
 test_that('five year window is in more recent data', {
@@ -112,8 +136,9 @@ test_that('get_raw_grate works with 5 year', {
   ex4 <- get_grad_rate(2016, '5 year')
   ex5 <- get_grad_rate(2017, '5 year')
   ex6 <- get_grad_rate(2018, '5 year')
+  ex7 <- get_grad_rate(2019, '5 year')
 
-  expect_is(ex0, 'data.frame')
+  #expect_is(ex0, 'data.frame')
   expect_is(ex1, 'data.frame')
   expect_is(ex2, 'data.frame')
   expect_is(ex3, 'data.frame')

--- a/tests/testthat/test_grate.R
+++ b/tests/testthat/test_grate.R
@@ -138,7 +138,7 @@ test_that('get_raw_grate works with 5 year', {
   ex6 <- get_grad_rate(2018, '5 year')
   ex7 <- get_grad_rate(2019, '5 year')
 
-  #expect_is(ex0, 'data.frame')
+  expect_is(ex0, 'data.frame')
   expect_is(ex1, 'data.frame')
   expect_is(ex2, 'data.frame')
   expect_is(ex3, 'data.frame')


### PR DESCRIPTION
Added 2020 and pointed older years to new URLs. 

 **Note that 2020 spreadsheet lacks graduated and cohort counts**

Also fixed all parsing errors caused by characters (N, *, -) in purportedly numeric columns like grad_count.

Finally, changed some code to use idiomatic tidyverse style (using .data[[i]] to access columns with quoted names). I left the loop, much to my chagrin. 