### PR TITLE
Fix UTF-8 encoding in directory functions for rpy2 compatibility

### DIFF
--- a/R/directory.R
+++ b/R/directory.R
@@ -17,8 +17,10 @@ get_district_directory <- function() {
     ) %>%
     dplyr::mutate(
       CDS_Code = paste0(county_id, district_id, '999')
-    )
-  
+    ) %>%
+    # Ensure UTF-8 encoding for all character columns (fixes rpy2 conversion issues)
+    dplyr::mutate(dplyr::across(dplyr::where(is.character), ~iconv(.x, to = "UTF-8", sub = "")))
+
   nj_dist
 }
 
@@ -29,7 +31,7 @@ get_district_directory <- function() {
 #' @export
 
 get_school_directory <- function() {
-  
+
   dir_url = "https://homeroom4.doe.state.nj.us/public/publicschools/download/"
   nj_sch <- readr::read_csv(dir_url, skip = 3) %>%
     janitor::clean_names() %>%
@@ -43,7 +45,9 @@ get_school_directory <- function() {
     ) %>%
     dplyr::mutate(
       CDS_Code = paste0(county_id, district_id, school_id)
-    )
-  
+    ) %>%
+    # Ensure UTF-8 encoding for all character columns (fixes rpy2 conversion issues)
+    dplyr::mutate(dplyr::across(dplyr::where(is.character), ~iconv(.x, to = "UTF-8", sub = "")))
+
   nj_sch
 }


### PR DESCRIPTION
## Summary
- Fix UnicodeDecodeError when converting R directory data frames to pandas via rpy2
- NJ DOE directory CSVs contain non-UTF-8 characters (e.g., accented names in Latin-1)
- Added `iconv()` transformation to ensure proper UTF-8 encoding

## Test plan
- [x] All 34 Python tests pass locally (previously 4 failing)
- [x] Directory integration tests now work correctly