### PR TITLE
Document committed-figure workflow and cache discipline in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,55 @@ Site: https://almartin82.github.io/njschooldata/
    {"build_type": "legacy", "source": {"branch": "gh-pages", "path": "/"}}
    EOF
    ```
+
+## Vignette Charts: Committed Figures Are the Source of Truth (REQUIRED)
+
+**Vignette figures are pre-rendered and committed to git. Editing a vignette's
+`.Rmd` does NOT update the published charts — you MUST regenerate and commit the
+figure PNGs.**
+
+- Rendered figures live in `vignettes/<vignette>_files/figure-html/*.png` and are
+  **tracked in git**. The pkgdown build serves these committed binaries; it does
+  not reliably re-knit them on every run.
+- The README/home page chart images point at the deployed copies
+  (`https://almartin82.github.io/njschooldata/articles/<vignette>_files/figure-html/<chunk>-1.png`),
+  which come from those same committed PNGs.
+
+**Workflow to update any chart (data refresh, new year, restyle):**
+1. Edit the vignette code/prose.
+2. Re-render locally: `rmarkdown::render("vignettes/<vignette>.Rmd")`.
+3. **Copy the regenerated `figure-html/*.png` over the committed ones and
+   `git add` them.** This step is the one that actually moves the published chart.
+4. Visually open the regenerated PNG and confirm it shows the new data before
+   committing — do not trust a green pkgdown build; the build can succeed while
+   serving stale committed figures.
+
+**Incident (2026-05, 2026 enrollment integration):** the vignette prose and data
+tables were updated to 2026 and merged, and pkgdown deployed green three times,
+but the live charts kept showing the old 2020-2025 series. Root cause: the
+committed `statewide-enrollment-1.png` (and 14 others) were never replaced, and
+the build served them byte-for-byte. The fix was committing the freshly rendered
+2026 PNGs. Two earlier attempts (changing `.Rmd` text, then `cache = FALSE`)
+failed because neither touched the committed figure binaries.
+
+## Vignette knitr Cache Discipline (REQUIRED)
+
+- Default the vignette chunk cache to **`cache = FALSE`** in the setup chunk.
+- Enable `cache = TRUE` **only** on the expensive data-fetch chunk (e.g.
+  `{r fetch-data, cache = TRUE}`), never on plot chunks.
+- Do **not** commit `vignettes/<vignette>_cache/` directories. Cached plot chunks
+  replay stale figures across build environments (the caschooldata 2026-03
+  incident); keeping plots un-cached forces a fresh render every time.
+
+## Data Source URLs Move Without Notice
+
+NJ DOE relocates and renames files frequently; the actual fetch URLs are built
+inside the fetch functions (not always `config_urls.R`). Two cases handled in
+code, kept here as a reminder to expect more:
+- **Enrollment** (`get_raw_enr`): the 2025-26 file shipped as `Enrollment_2526.zip`
+  (capital E) vs the historical lowercase `enrollment_*.zip`; the fetcher tries
+  both capitalizations.
+- **Graduation** (`get_raw_grad_file`): in 2026 the entire
+  `/schoolperformance/grad/` tree was retired and files moved to
+  `/spr/adddata/doc/acgrdocs/`. `fetch_postsecondary()` points at the old tree and
+  its file did not move there — its new location is still unknown (open follow-up).


### PR DESCRIPTION
Documents the lessons from the 2026 enrollment integration so future chart updates don't repeat the stale-figure mistake:

- **Committed figures are the source of truth** — `vignettes/<vig>_files/figure-html/*.png` are tracked and served by pkgdown; editing the `.Rmd` alone won't move the published charts. Must regenerate + commit the PNGs, and visually verify (a green build can serve stale figures).
- **Cache discipline** — global `cache = FALSE`, only fetch chunks cache, don't commit `_cache/`.
- **NJ DOE URLs move** — enrollment filename case flip and the graduation tree relocation to `/spr/adddata/doc/acgrdocs/`.

Docs-only change.