### PR TITLE
Note 2026 vignette/README refresh in NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,13 @@
 * Fixed stale `test_validation.R` assertions that expected 1999 enrollment to
   be valid (1999 was removed from the NJ DOE website; the range starts at 2000).
 
+## Documentation
+
+* Refreshed the enrollment vignette and README to the 2020-2026 window, with all
+  15 stories recomputed and the committed `figure-html` charts regenerated so the
+  published site reflects 2026. Plot chunks now default to `cache = FALSE` to
+  prevent stale cached figures.
+
 # njschooldata 0.9.0
 
 ## New features


### PR DESCRIPTION
Adds a Documentation subsection under the 0.9.1 NEWS entry recording that the enrollment vignette/README were refreshed to the 2020-2026 window with regenerated committed charts (PRs #236-#237), and that plot chunks default to cache = FALSE. Docs-only.