### PR TITLE
Extend assessment fetchers to SY2024-25 (end_year 2025)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: A Simple Interface for Accessing NJ DOE School Data in R and Python
 Description: R functions (with Python bindings) to import NJ school data,
     including assessment, enrollment, and accountability data from the
     New Jersey Department of Education.
-Version: 0.9.2
+Version: 0.9.3
 Authors@R: person("Andrew", "Martin", role = c("aut","cre"),
     email = "almartin@gmail.com")
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# njschooldata 0.9.2
+# njschooldata 0.9.3
 
 ## New features
 
@@ -15,6 +15,11 @@
   NJ DOE has used since 2022. The old `gsub("ALG", "ALG0", ...)` step left `GEO`
   unchanged, so `fetch_parcc(year, "GEO", "math")` silently 404'd for 2022-2024.
   Geometry results now fetch for all of 2022-2025.
+
+# njschooldata 0.9.2
+
+## Bug fixes
+
 * `fetch_enr()` now works end-to-end for 1999-2009. Pre-2010 NJDOE files arrive
   with combined "01-ATLANTIC" strings in the `COUNTY` / `DISTRICT` / `SCHOOL`
   columns. `clean_enr_names()` renames those to `county_name` / `district_name`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,20 @@
 # njschooldata 0.9.2
 
+## New features
+
+* Assessment fetchers (`fetch_parcc()`/NJSLA, `fetch_njgpa()`, `fetch_access()`,
+  plus `fetch_all_parcc()`/`fetch_all_njgpa()`/`fetch_all_access()`) now cover
+  SY2024-25 (`end_year = 2025`). NJ DOE reverted to the 2019-era space-encoded
+  filenames for 2025 (e.g. `ELA03%20NJSLA%20DATA%202024-25.xlsx`); the URL
+  builders now use spaces for 2019 and 2025+ and underscores for 2022-2024.
+  `PARCC_VALID_YEARS` extends to 2025. Schemas are unchanged from 2024.
+
 ## Bug fixes
 
+* `get_raw_sla()` now maps the Geometry math test code `GEO` to `GEO01`, which
+  NJ DOE has used since 2022. The old `gsub("ALG", "ALG0", ...)` step left `GEO`
+  unchanged, so `fetch_parcc(year, "GEO", "math")` silently 404'd for 2022-2024.
+  Geometry results now fetch for all of 2022-2025.
 * `fetch_enr()` now works end-to-end for 1999-2009. Pre-2010 NJDOE files arrive
   with combined "01-ATLANTIC" strings in the `COUNTY` / `DISTRICT` / `SCHOOL`
   columns. `clean_enr_names()` renames those to `county_name` / `district_name`

--- a/R/config_years.R
+++ b/R/config_years.R
@@ -22,7 +22,7 @@ ENR_VALID_YEARS <- 1999:2026
 
 #' PARCC/NJSLA assessment valid years (skip 2020 - no testing due to COVID)
 #' @keywords internal
-PARCC_VALID_YEARS <- c(2015:2019, 2021:2024)
+PARCC_VALID_YEARS <- c(2015:2019, 2021:2025)
 
 #' 4-year graduation rate valid years
 #' @keywords internal

--- a/R/fetch_assessment.R
+++ b/R/fetch_assessment.R
@@ -78,6 +78,8 @@ get_raw_sla <- function(end_year, grade_or_subj, subj) {
     subj_prefix <- parse_parcc_subj(subj)
   } else if (grepl("ALG|GEO", grade_or_subj)) {
     parcc_grade <- gsub("ALG", "ALG0", grade_or_subj)
+    # NJ DOE has used GEO01 (not GEO) since 2022; map GEO -> GEO01
+    parcc_grade <- gsub("^GEO$", "GEO01", parcc_grade)
     subj_prefix <- ""
   } else {
     parcc_grade <- grade_or_subj
@@ -87,15 +89,16 @@ get_raw_sla <- function(end_year, grade_or_subj, subj) {
   stem <- "https://www.nj.gov/education/assessment/results/reports/"
   year_suffix <- paste0(end_year - 1, "-", substr(end_year, 3, 4))
 
-  # URL format changed between 2019 and 2022
-  # 2019: ELA03%20NJSLA%20DATA%202018-19.xlsx (spaces)
-  # 2022+: ELA03_NJSLA_DATA_2021-22.xlsx (underscores)
-  if (end_year == 2019) {
+  # NJ DOE filename encoding has flip-flopped over the years:
+  #   2019:      ELA03%20NJSLA%20DATA%202018-19.xlsx (spaces)
+  #   2022-2024: ELA03_NJSLA_DATA_2021-22.xlsx       (underscores)
+  #   2025:      ELA03%20NJSLA%20DATA%202024-25.xlsx (spaces again)
+  if (end_year == 2019 || end_year >= 2025) {
     filename <- paste0(
       subj_prefix, parcc_grade, "%20NJSLA%20DATA%20", year_suffix, ".xlsx"
     )
   } else {
-    # 2022 and later use underscores
+    # 2022-2024 use underscores
     filename <- paste0(
       subj_prefix, parcc_grade, "_NJSLA_DATA_", year_suffix, ".xlsx"
     )
@@ -120,7 +123,7 @@ get_raw_sla <- function(end_year, grade_or_subj, subj) {
 #' NJGPA (New Jersey Graduation Proficiency Assessment) is the graduation
 #' requirement assessment introduced in 2022.
 #'
-#' @param end_year A school year. Valid values are 2022-2024.
+#' @param end_year A school year. Valid values are 2022-2025.
 #' @param subj NJGPA subject. c('ela' or 'math')
 #' @return NJGPA dataframe
 #' @keywords internal
@@ -138,7 +141,14 @@ get_raw_njgpa <- function(end_year, subj) {
   stem <- "https://www.nj.gov/education/assessment/results/reports/"
   year_suffix <- paste0(end_year - 1, "-", substr(end_year, 3, 4))
 
-  filename <- paste0(subj_prefix, "_NJGPA_DATA_", year_suffix, ".xlsx")
+  # NJ DOE filename encoding flip-flopped, mirroring the NJSLA files:
+  #   2022-2024: ELAGP_NJGPA_DATA_2021-22.xlsx       (underscores)
+  #   2025:      ELAGP%20NJGPA%20DATA%202024-25.xlsx (spaces)
+  if (end_year >= 2025) {
+    filename <- paste0(subj_prefix, "%20NJGPA%20DATA%20", year_suffix, ".xlsx")
+  } else {
+    filename <- paste0(subj_prefix, "_NJGPA_DATA_", year_suffix, ".xlsx")
+  }
 
   target_url <- paste0(
     stem, substr(end_year - 1, 3, 4), substr(end_year, 3, 4), "/njgpa/", filename
@@ -162,7 +172,7 @@ get_raw_njgpa <- function(end_year, subj) {
 #' that gets a parcc file and performs any cleanup.
 #'
 #' @param end_year A school year. end_year is the end of the academic year - eg 2014-15
-#' school year is end_year 2015. Valid values are 2015-2024.
+#' school year is end_year 2015. Valid values are 2015-2025.
 #' @param grade_or_subj Grade level (eg 8) OR math subject code (eg ALG1, GEO, ALG2).
 #'   For science, valid grades are 5, 8, and 11.
 #' @param subj Assessment subject: 'ela', 'math', or 'science'.
@@ -220,7 +230,7 @@ fetch_parcc <- function(end_year, grade_or_subj, subj, tidy = FALSE) {
 #' requirement assessment introduced in 2022, replacing the previous PARCC-based
 #' graduation pathway.
 #'
-#' @param end_year A school year. Valid values are 2022-2024.
+#' @param end_year A school year. Valid values are 2022-2025.
 #' @param subj Assessment subject: 'ela' or 'math'
 #' @param tidy Clean up the data frame? Default is FALSE.
 #' @return Processed NJGPA dataframe
@@ -276,7 +286,7 @@ fetch_all_parcc <- function(include_science = TRUE) {
 
   # Note: 2020 assessments cancelled due to COVID-19
   # Note: 2021 only has "Start Strong" pilot data, not standard NJSLA
-  valid_years <- c(2015:2019, 2022:2024)
+  valid_years <- c(2015:2019, 2022:2025)
 
   for (i in valid_years) {
     # Normal grade level tests
@@ -392,7 +402,7 @@ fetch_all_njgpa <- function() {
   njgpa_results <- list()
 
   # NJGPA started in 2022
-  valid_years <- c(2022:2024)
+  valid_years <- c(2022:2025)
 
   for (i in valid_years) {
     for (k in c("ela", "math")) {
@@ -425,7 +435,7 @@ fetch_all_njgpa <- function() {
 #' Builds the URL for a given year's ACCESS data file.
 #' URL structure changed between years.
 #'
-#' @param end_year A school year (2022-2024)
+#' @param end_year A school year (2022-2025)
 #' @return URL string
 #' @keywords internal
 get_access_url <- function(end_year) {
@@ -457,7 +467,7 @@ get_access_url <- function(end_year) {
 #'
 #' Downloads the ACCESS file and reads a specific grade sheet.
 #'
-#' @param end_year A school year (2022-2024)
+#' @param end_year A school year (2022-2025)
 #' @param grade Grade level: "K" or 0 for Kindergarten, or 1-12 for other grades.
 #'   Use "all" to get all grades combined.
 #' @return ACCESS dataframe for the specified grade
@@ -515,7 +525,7 @@ get_raw_access <- function(end_year, grade = "all") {
 #' Cleans and standardizes ACCESS data.
 #'
 #' @param access_file Output of get_raw_access
-#' @param end_year A school year (2022-2024)
+#' @param end_year A school year (2022-2025)
 #' @return Processed ACCESS dataframe
 #' @keywords internal
 process_access <- function(access_file, end_year) {
@@ -591,7 +601,7 @@ process_access <- function(access_file, end_year) {
 #' assessment results. ACCESS measures English language proficiency
 #' for ELL students across grades K-12.
 #'
-#' @param end_year A school year. Valid values are 2022-2024.
+#' @param end_year A school year. Valid values are 2022-2025.
 #' @param grade Grade level: "K" or 0 for Kindergarten, 1-12 for other grades,
 #'   or "all" (default) to get all grades combined.
 #' @return Processed ACCESS dataframe with columns including:
@@ -630,7 +640,7 @@ fetch_access <- function(end_year, grade = "all") {
 #' Convenience function to download and combine all available ACCESS
 #' for ELLs results into a single data frame.
 #'
-#' @return A data frame with all ACCESS results (2022-2024, all grades)
+#' @return A data frame with all ACCESS results (2022-2025, all grades)
 #' @export
 #' @examples
 #' \dontrun{
@@ -641,8 +651,8 @@ fetch_all_access <- function() {
 
   access_results <- list()
 
-  # ACCESS data available 2022-2024
-  valid_years <- c(2022:2024)
+  # ACCESS data available 2022-2025
+  valid_years <- c(2022:2025)
 
   for (year in valid_years) {
     result <- tryCatch(

--- a/man/PARCC_VALID_YEARS.Rd
+++ b/man/PARCC_VALID_YEARS.Rd
@@ -5,7 +5,7 @@
 \alias{PARCC_VALID_YEARS}
 \title{PARCC/NJSLA assessment valid years (skip 2020 - no testing due to COVID)}
 \format{
-An object of class \code{integer} of length 9.
+An object of class \code{integer} of length 10.
 }
 \usage{
 PARCC_VALID_YEARS

--- a/man/fetch_access.Rd
+++ b/man/fetch_access.Rd
@@ -7,7 +7,7 @@
 fetch_access(end_year, grade = "all")
 }
 \arguments{
-\item{end_year}{A school year. Valid values are 2022-2024.}
+\item{end_year}{A school year. Valid values are 2022-2025.}
 
 \item{grade}{Grade level: "K" or 0 for Kindergarten, 1-12 for other grades,
 or "all" (default) to get all grades combined.}

--- a/man/fetch_all_access.Rd
+++ b/man/fetch_all_access.Rd
@@ -7,7 +7,7 @@
 fetch_all_access()
 }
 \value{
-A data frame with all ACCESS results (2022-2024, all grades)
+A data frame with all ACCESS results (2022-2025, all grades)
 }
 \description{
 Convenience function to download and combine all available ACCESS

--- a/man/fetch_njgpa.Rd
+++ b/man/fetch_njgpa.Rd
@@ -7,7 +7,7 @@
 fetch_njgpa(end_year, subj, tidy = FALSE)
 }
 \arguments{
-\item{end_year}{A school year. Valid values are 2022-2024.}
+\item{end_year}{A school year. Valid values are 2022-2025.}
 
 \item{subj}{Assessment subject: 'ela' or 'math'}
 

--- a/man/fetch_parcc.Rd
+++ b/man/fetch_parcc.Rd
@@ -8,7 +8,7 @@ fetch_parcc(end_year, grade_or_subj, subj, tidy = FALSE)
 }
 \arguments{
 \item{end_year}{A school year. end_year is the end of the academic year - eg 2014-15
-school year is end_year 2015. Valid values are 2015-2024.}
+school year is end_year 2015. Valid values are 2015-2025.}
 
 \item{grade_or_subj}{Grade level (eg 8) OR math subject code (eg ALG1, GEO, ALG2).
 For science, valid grades are 5, 8, and 11.}

--- a/man/get_access_url.Rd
+++ b/man/get_access_url.Rd
@@ -7,7 +7,7 @@
 get_access_url(end_year)
 }
 \arguments{
-\item{end_year}{A school year (2022-2024)}
+\item{end_year}{A school year (2022-2025)}
 }
 \value{
 URL string

--- a/man/get_raw_access.Rd
+++ b/man/get_raw_access.Rd
@@ -7,7 +7,7 @@
 get_raw_access(end_year, grade = "all")
 }
 \arguments{
-\item{end_year}{A school year (2022-2024)}
+\item{end_year}{A school year (2022-2025)}
 
 \item{grade}{Grade level: "K" or 0 for Kindergarten, or 1-12 for other grades.
 Use "all" to get all grades combined.}

--- a/man/get_raw_njgpa.Rd
+++ b/man/get_raw_njgpa.Rd
@@ -7,7 +7,7 @@
 get_raw_njgpa(end_year, subj)
 }
 \arguments{
-\item{end_year}{A school year. Valid values are 2022-2024.}
+\item{end_year}{A school year. Valid values are 2022-2025.}
 
 \item{subj}{NJGPA subject. c('ela' or 'math')}
 }

--- a/man/process_access.Rd
+++ b/man/process_access.Rd
@@ -9,7 +9,7 @@ process_access(access_file, end_year)
 \arguments{
 \item{access_file}{Output of get_raw_access}
 
-\item{end_year}{A school year (2022-2024)}
+\item{end_year}{A school year (2022-2025)}
 }
 \value{
 Processed ACCESS dataframe


### PR DESCRIPTION
## Summary

Extends the NJSLA/NJGPA/ACCESS assessment fetchers to cover SY2024-25 (`end_year = 2025`). NJ DOE reverted to the 2019-era space-encoded filenames for the 2024-25 files (e.g. `ELA03%20NJSLA%20DATA%202024-25.xlsx`), so this is primarily a URL-encoding fix plus a valid-years bump. The data schema is byte-identical to 2024, so no parser/column changes were needed.

## Changes

- **`R/config_years.R`**: `PARCC_VALID_YEARS` `c(2015:2019, 2021:2024)` → `c(2015:2019, 2021:2025)`.
- **`R/fetch_assessment.R`**:
  - `get_raw_sla()`: use space-encoded filenames for `end_year == 2019 || end_year >= 2025`, underscores for 2022-2024. (Filename history: 2019 spaces → 2022-2024 underscores → 2025 spaces again.)
  - `get_raw_njgpa()`: add a 2025+ space-encoded branch (`ELAGP%20NJGPA%20DATA%202024-25.xlsx`); 2022-2024 keep underscores.
  - `fetch_all_parcc()`, `fetch_all_njgpa()`, `fetch_all_access()`: valid-year ranges bumped to 2025.
  - Roxygen `@param end_year` valid-value docs updated 2022-2024 → 2022-2025.
- **Pre-existing bug fix (`get_raw_sla`)**: the Geometry math code `GEO` was never rewritten to `GEO01` (NJ DOE's filename since 2022). The old `gsub("ALG", "ALG0", ...)` left `GEO` unchanged, so `fetch_parcc(year, "GEO", "math")` silently 404'd for **2022-2024**. Now mapped `GEO` → `GEO01`, fixing Geometry for all of 2022-2025.
- **`NEWS.md`**: new-features + bug-fix bullets under 0.9.2.
- `man/*.Rd` regenerated via `devtools::document()` for the touched functions.

## Live verification (against live NJ DOE URLs, R 4.5.0)

Raw fetchers (rows of real data):
- `get_raw_sla(2025, 3, "ela")` → 25,885 rows
- `get_raw_sla(2025, 8, "math")` → 16,182 rows
- `get_raw_sla(2025, "GEO", "math")` → 11,332 rows (downloads `GEO01...`)
- `get_raw_sla(2025, "ALG1", "math")` → 22,149 rows
- `get_raw_sla(2025, 5, "science")` → 24,123 rows
- `get_raw_njgpa(2025, "ela")` → 11,227 rows; `get_raw_njgpa(2025, "math")` → 11,226 rows

End-to-end (`tidy = TRUE`):
- `fetch_parcc(2025, 3, "math")` → 25,932 rows
- `fetch_parcc(2025, "GEO", "math")` → 11,332 rows
- `fetch_njgpa(2025, "ela")` → 11,227 rows
- `fetch_access(2025)` → 14,663 rows

Magnitude sanity checks (statewide totals, plausible tens-of-thousands):
- NJSLA grade 3 math 2025 statewide `total_population` valid scores = **95,272**
- NJGPA ELA 2025 statewide TOTAL valid scores = **102,406** (104,247 enrolled)
- ACCESS 2025 sum of school-level valid scores = **113,295**
- GEO fix also repairs 2024: statewide valid scores 2024 = 30,556, 2025 = 29,840

Schema comparison (2024 vs 2025 raw `names()`):
- NJSLA ELA03, GEO, SC05 and ACCESS: **identical**.
- NJGPA: the only difference is one word inside NJ DOE's own multi-line footnote text baked into the "Not Tested" header cell ("(See Below)" in 2024 vs "(See Above)" in 2025). Column count and tidy output columns are identical (34 cols both years). No parser change required.

## Notes / follow-up

- NJGPA produces no `is_state` + `total_population` row in either 2024 or 2025 (it uses raw subgroup labels `TOTAL` / `RACE/ETHNICITY` / `GENDER` / `SUBGROUP`). This is unchanged pre-existing behavior, not introduced here.
- Chronic-absenteeism and enrollment year constants were intentionally left untouched (out of scope / owned elsewhere).