### PR TITLE
Extend 4-year and 6-year graduation fetchers to SY2024-25 (end_year 2025)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,18 +8,6 @@
   filenames for 2025 (e.g. `ELA03%20NJSLA%20DATA%202024-25.xlsx`); the URL
   builders now use spaces for 2019 and 2025+ and underscores for 2022-2024.
   `PARCC_VALID_YEARS` extends to 2025. Schemas are unchanged from 2024.
-
-## Bug fixes
-
-* `get_raw_sla()` now maps the Geometry math test code `GEO` to `GEO01`, which
-  NJ DOE has used since 2022. The old `gsub("ALG", "ALG0", ...)` step left `GEO`
-  unchanged, so `fetch_parcc(year, "GEO", "math")` silently 404'd for 2022-2024.
-  Geometry results now fetch for all of 2022-2025.
-
-# njschooldata 0.9.2
-
-## New features
-
 * Extend the 4-year and 6-year graduation fetchers to SY2024-25 (end_year
   2025). `fetch_grad_rate(2025, "4 year")`, `fetch_grad_count(2025)`, and
   `fetch_6yr_grad_rate(2025)` (school and district) now work. NJ DOE
@@ -32,6 +20,15 @@
   values). Subgroup labels renamed by NJ DOE (`Total` -> `All Students`,
   `Hispanic` -> `Hispanic/Latino`) are normalized back to the package's
   standard names so cross-year filters keep working.
+
+## Bug fixes
+
+* `get_raw_sla()` now maps the Geometry math test code `GEO` to `GEO01`, which
+  NJ DOE has used since 2022. The old `gsub("ALG", "ALG0", ...)` step left `GEO`
+  unchanged, so `fetch_parcc(year, "GEO", "math")` silently 404'd for 2022-2024.
+  Geometry results now fetch for all of 2022-2025.
+
+# njschooldata 0.9.2
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # njschooldata 0.9.2
 
+## New features
+
+* Extend the 4-year and 6-year graduation fetchers to SY2024-25 (end_year
+  2025). `fetch_grad_rate(2025, "4 year")`, `fetch_grad_count(2025)`, and
+  `fetch_6yr_grad_rate(2025)` (school and district) now work. NJ DOE
+  restructured the SY2024-25 files: the 4-year ACGR file (`Cohort2025`)
+  renamed `Graduation Rate` -> `Adjusted Cohort Graduation Rate` and
+  `Cohort Count` -> `Adjusted Cohort Count`; the SPR 6-year cohort data moved
+  from the `6YrGraduationCohortProfile` sheet to the combined
+  `GraduationCohortProfile` sheet (filtered on `CohortType == "6-Year"`, header
+  on row 4, `_School`/`_District`/`_State` column suffixes, percent-string rate
+  values). Subgroup labels renamed by NJ DOE (`Total` -> `All Students`,
+  `Hispanic` -> `Hispanic/Latino`) are normalized back to the package's
+  standard names so cross-year filters keep working.
+
 ## Bug fixes
 
 * `fetch_enr()` now works end-to-end for 1999-2009. Pre-2010 NJDOE files arrive

--- a/R/config_years.R
+++ b/R/config_years.R
@@ -26,7 +26,7 @@ PARCC_VALID_YEARS <- c(2015:2019, 2021:2024)
 
 #' 4-year graduation rate valid years
 #' @keywords internal
-GRATE_4YR_VALID_YEARS <- 2011:2024
+GRATE_4YR_VALID_YEARS <- 2011:2025
 
 #' 5-year graduation rate valid years
 #' @keywords internal
@@ -34,7 +34,7 @@ GRATE_5YR_VALID_YEARS <- 2012:2019
 
 #' Graduation count valid years
 #' @keywords internal
-GCOUNT_VALID_YEARS <- 1998:2024
+GCOUNT_VALID_YEARS <- 1998:2025
 
 #' Legacy assessment (NJASK/HSPA/GEPA) valid years
 #' @keywords internal

--- a/R/fetch_graduation.R
+++ b/R/fetch_graduation.R
@@ -10,14 +10,14 @@
 #' Get a raw graduation file from the NJ website
 #'
 #' @param end_year End of the academic year - eg 2006-07 is 2007.
-#' Valid values are 1998-2024.
+#' Valid values are 1998-2025.
 #' @param methodology One of c('4 year', '5 year')
 #' @return data.frame with raw data from state file
 #' @keywords internal
 get_raw_grad_file <- function(end_year, methodology = "4 year") {
 
-  if (end_year < 1998 | end_year > 2024) {
-    stop("year not yet supported. Valid years are 1998-2024.")
+  if (end_year < 1998 | end_year > 2025) {
+    stop("year not yet supported. Valid years are 1998-2025.")
   }
 
   # In 2026 NJ DOE retired the /schoolperformance/grad/ tree (data/ and docs/)
@@ -115,6 +115,15 @@ get_raw_grad_file <- function(end_year, methodology = "4 year") {
       grate_file <- tempfile(fileext = ".xlsx")
       httr::GET(url = grate_url, httr::write_disk(grate_file))
       df <- readxl::read_excel(grate_file, skip = num_skip)
+    } else if (end_year == 2025) {
+      # Cohort2025 keeps the row-6 header (num_skip = 5) but renamed columns:
+      # "Graduation Rate" -> "Adjusted Cohort Graduation Rate",
+      # "Cohort Count" -> "Adjusted Cohort Count" (handled in process_grate()).
+      grate_url <- "https://www.nj.gov/education/spr/adddata/doc/acgrdocs/Cohort2025_4YearAdjustedCohortGraduationRatesbyStudentGroup.xlsx"
+      num_skip <- 5
+      grate_file <- tempfile(fileext = ".xlsx")
+      httr::GET(url = grate_url, httr::write_disk(grate_file))
+      df <- readxl::read_excel(grate_file, skip = num_skip)
     }
 
     ########## 5 year ##########
@@ -164,12 +173,12 @@ get_raw_grad_file <- function(end_year, methodology = "4 year") {
 #' Get NJ graduation count data
 #'
 #' @param end_year End of the academic year - eg 2006-07 is 2007.
-#' Valid values are 2012-2024.
+#' Valid values are 2012-2025.
 #' @return dataframe with the number of graduates per school and district
 #' @keywords internal
 get_grad_count <- function(end_year) {
-  if (end_year < 2012 | end_year > 2024) {
-    stop(paste0(end_year, " not yet supported. Valid years are 2012-2024."))
+  if (end_year < 2012 | end_year > 2025) {
+    stop(paste0(end_year, " not yet supported. Valid years are 2012-2025."))
   }
 
   df <- get_raw_grad_file(end_year)
@@ -182,14 +191,14 @@ get_grad_count <- function(end_year) {
 #' Get NJ graduation rate data
 #'
 #' @param end_year End of the academic year - 2011-2012 is 2012.
-#' Valid values are 2011-2024.
+#' Valid values are 2011-2025.
 #' @param methodology Character string specifying calculation methodology.
 #' One of "4 year" or "5 year".
 #' @return dataframe with the number of graduates per school and district
 #' @keywords internal
 get_grad_rate <- function(end_year, methodology) {
-  if (end_year < 2011 | end_year > 2024) {
-    stop("year not yet supported. Valid years are 2011-2024.")
+  if (end_year < 2011 | end_year > 2025) {
+    stop("year not yet supported. Valid years are 2011-2025.")
   }
 
   df <- get_raw_grad_file(end_year, methodology) %>%
@@ -205,7 +214,7 @@ get_grad_rate <- function(end_year, methodology) {
 #' Downloads and processes graduation count data.
 #'
 #' @param end_year End of the academic year - eg 2006-07 is 2007.
-#' Valid values are 2012-2024.
+#' Valid values are 2012-2025.
 #' @return dataframe with grad counts
 #' @export
 #' @examples
@@ -249,7 +258,7 @@ fetch_grad_count <- function(end_year) {
 #' Downloads and processes graduation rate data.
 #'
 #' @param end_year End of the academic year - eg 2006-07 is 2007.
-#' Valid values are 2011-2024.
+#' Valid values are 2011-2025.
 #' @param methodology Character string specifying calculation methodology.
 #' One of "4 year" or "5 year".
 #' @return dataframe with grad rate
@@ -303,14 +312,14 @@ fetch_grad_rate <- function(end_year, methodology = "4 year") {
 #' Builds the URL for the School Performance Reports database containing
 #' 6-year graduation cohort profile data.
 #'
-#' @param end_year A school year (2021-2024). Year is the end of the academic
+#' @param end_year A school year (2021-2025). Year is the end of the academic
 #'   year - eg 2020-21 school year is end_year '2021'.
 #' @param level One of "school" or "district". Determines which database file
 #'   to download.
 #' @return URL string
 #' @keywords internal
 get_spr_6yr_grad_url <- function(end_year, level = "school") {
-  valid_years <- c(2021, 2022, 2023, 2024)
+  valid_years <- c(2021, 2022, 2023, 2024, 2025)
   if (!end_year %in% valid_years) {
     stop(paste0(
       "6-year graduation rate data is available for years: ",
@@ -346,12 +355,16 @@ get_spr_6yr_grad_url <- function(end_year, level = "school") {
 #' @keywords internal
 clean_6yr_grad_subgroups <- function(group) {
   dplyr::case_when(
-    tolower(group) %in% c("schoolwide", "districtwide") ~ "total population",
+    # 2024-25 SPR uses "All Students" for the total row; earlier years used
+    # "Schoolwide"/"Districtwide"
+    tolower(group) %in% c("schoolwide", "districtwide", "all students") ~ "total population",
     tolower(group) == "american indian or alaska native" ~ "american indian",
     tolower(group) == "black or african american" ~ "black",
     tolower(group) == "economically disadvantaged students" ~ "economically disadvantaged",
     tolower(group) %in% c("english learners", "multilingual learners") ~ "limited english proficiency",
-    tolower(group) == "two or more races" ~ "multiracial",
+    tolower(group) %in% c("two or more races") ~ "multiracial",
+    # 2024-25 SPR renamed "Hispanic" -> "Hispanic/Latino"
+    tolower(group) %in% c("hispanic", "hispanic/latino") ~ "hispanic",
     tolower(group) == "native hawaiian or pacific islander" ~ "pacific islander",
     tolower(group) == "asian, native hawaiian, or pacific islander" ~ "asian",
     tolower(group) == "students with disabilities" ~ "students with disabilities",
@@ -371,7 +384,7 @@ clean_6yr_grad_subgroups <- function(group) {
 #' fetch function rather than being an option in \code{fetch_grad_rate()}.
 #'
 #' @param end_year A school year. Year is the end of the academic year - eg
-#'   2020-21 school year is end_year '2021'. Valid values are 2021-2024.
+#'   2020-21 school year is end_year '2021'. Valid values are 2021-2025.
 #' @param level One of "school" or "district". "school" returns school-level
 #'   data, "district" returns district and state-level data.
 #' @return dataframe with 6-year graduation rates including:
@@ -399,85 +412,186 @@ fetch_6yr_grad_rate <- function(end_year, level = "school") {
   target_url <- get_spr_6yr_grad_url(end_year, level)
 
   tname <- tempfile(pattern = "spr_6yr", tmpdir = tempdir(), fileext = ".xlsx")
+
+  # The SPR database files are large (the 2024-25 school file is ~368 MB), so
+  # bump the download timeout above R's 60-second default for the duration of
+  # the fetch and restore it afterward.
+  old_timeout <- getOption("timeout")
+  on.exit(options(timeout = old_timeout), add = TRUE)
+  options(timeout = max(old_timeout, 1200))
+
   downloader::download(target_url, destfile = tname, mode = "wb")
 
-  # Read 6YrGraduationCohortProfile sheet
-  df <- readxl::read_excel(
-    path = tname,
-    sheet = "6YrGraduationCohortProfile",
-    na = c("*", "N", "NA", "", "-"),
-    guess_max = 10000
-  )
+  if (end_year >= 2025) {
+    # SY2024-25 restructured the SPR database: the 6-year cohort profile moved
+    # from the "6YrGraduationCohortProfile" sheet to the combined
+    # "GraduationCohortProfile" sheet (which now holds 4/5/6-year cohorts and
+    # requires filtering CohortType == "6-Year"). Headers moved to row 4
+    # (skip = 3), rate columns gained _School/_District/_State suffixes, and
+    # rate values are now percent strings (e.g. "81.6%").
+    suppressers <- c(
+      "*", "N", "NA", "", "-", "n/a",
+      "Fewer than 10 students in the cohort.",
+      "Fewer than 10 graduates."
+    )
+    df <- readxl::read_excel(
+      path = tname,
+      sheet = "GraduationCohortProfile",
+      skip = 3,
+      na = suppressers,
+      guess_max = 30000
+    )
 
-  # Check if HighSchoolPersistance column exists (added in 2024)
-  has_persistence <- "HighSchoolPersistance" %in% names(df) |
-    "StateHighSchoolPersistance" %in% names(df)
-
-  # Standardize column names based on level
-  if (level == "school") {
     df <- df %>%
-      dplyr::rename(
-        county_id = CountyCode,
-        county_name = CountyName,
-        district_id = DistrictCode,
-        district_name = DistrictName,
-        school_id = SchoolCode,
-        school_name = SchoolName,
-        subgroup = StudentGroup,
-        grad_rate_6yr = Graduates,
-        continuing_rate = `Continuing Students`,
-        non_continuing_rate = `Non-Continuing Student`
-      )
+      dplyr::filter(.data$CohortType == "6-Year")
 
-    # Add persistence_rate if available, otherwise calculate or set NA
-    if (has_persistence) {
-      df <- df %>% dplyr::rename(persistence_rate = HighSchoolPersistance)
+    if (level == "school") {
+      df <- df %>%
+        dplyr::rename(
+          county_id = CountyCode,
+          county_name = CountyName,
+          district_id = DistrictCode,
+          district_name = DistrictName,
+          school_id = SchoolCode,
+          school_name = SchoolName,
+          subgroup = StudentGroup,
+          grad_rate_6yr = Graduated_School,
+          continuing_rate = Continuing_School,
+          non_continuing_rate = NonContinuing_School,
+          persistence_rate = Persisting_School
+        ) %>%
+        dplyr::select(
+          county_id, county_name,
+          district_id, district_name,
+          school_id, school_name,
+          subgroup,
+          grad_rate_6yr, continuing_rate, non_continuing_rate, persistence_rate
+        )
     } else {
-      # Calculate persistence = graduates + continuing (not available in early years)
-      df <- df %>% dplyr::mutate(persistence_rate = NA_real_)
+      # District file has no SchoolCode/SchoolName. Real district rows carry
+      # their rate in the _District columns; the statewide aggregate row leaves
+      # _District blank and only populates _State, so coalesce District -> State.
+      df <- df %>%
+        dplyr::rename(
+          county_id = CountyCode,
+          county_name = CountyName,
+          district_id = DistrictCode,
+          district_name = DistrictName,
+          subgroup = StudentGroup
+        ) %>%
+        dplyr::mutate(
+          grad_rate_6yr = dplyr::coalesce(Graduated_District, Graduated_State),
+          continuing_rate = dplyr::coalesce(Continuing_District, Continuing_State),
+          non_continuing_rate = dplyr::coalesce(NonContinuing_District, NonContinuing_State),
+          persistence_rate = dplyr::coalesce(Persisting_District, Persisting_State),
+          school_id = "999",
+          school_name = "District Total"
+        ) %>%
+        dplyr::select(
+          county_id, county_name,
+          district_id, district_name,
+          school_id, school_name,
+          subgroup,
+          grad_rate_6yr, continuing_rate, non_continuing_rate, persistence_rate
+        )
     }
 
-    df <- df %>%
-      dplyr::select(
-        county_id, county_name,
-        district_id, district_name,
-        school_id, school_name,
-        subgroup,
-        grad_rate_6yr, continuing_rate, non_continuing_rate, persistence_rate
-      )
-  } else {
-    # District file doesn't have SchoolCode/SchoolName
-    df <- df %>%
-      dplyr::rename(
-        county_id = CountyCode,
-        county_name = CountyName,
-        district_id = DistrictCode,
-        district_name = DistrictName,
-        subgroup = StudentGroup,
-        grad_rate_6yr = Graduates,
-        continuing_rate = `Continuing Students`,
-        non_continuing_rate = `Non-Continuing Student`
-      )
-
-    # Add persistence_rate if available, otherwise set NA
-    if (has_persistence) {
-      df <- df %>% dplyr::rename(persistence_rate = HighSchoolPersistance)
-    } else {
-      df <- df %>% dplyr::mutate(persistence_rate = NA_real_)
+    # Strip the trailing "%" from percent strings before numeric coercion.
+    rate_cols <- c("grad_rate_6yr", "continuing_rate", "non_continuing_rate", "persistence_rate")
+    for (col in rate_cols) {
+      df[[col]] <- gsub("%", "", as.character(df[[col]]), fixed = TRUE)
     }
 
+    # In the 2024-25 GraduationCohortProfile sheet the statewide row carries the
+    # literal string "State" in CountyCode/DistrictCode rather than the numeric
+    # 99/9999 codes used elsewhere. Normalize so the aggregation flags below
+    # (is_state, is_district, ...) classify it correctly.
     df <- df %>%
       dplyr::mutate(
-        school_id = "999",
-        school_name = "District Total"
-      ) %>%
-      dplyr::select(
-        county_id, county_name,
-        district_id, district_name,
-        school_id, school_name,
-        subgroup,
-        grad_rate_6yr, continuing_rate, non_continuing_rate, persistence_rate
+        district_id = dplyr::if_else(district_id == "State", "9999", district_id),
+        county_id = dplyr::if_else(county_id == "State", "99", county_id)
       )
+  } else {
+    # 2017-2024: legacy "6YrGraduationCohortProfile" sheet, headers on row 1,
+    # numeric rate columns named Graduates / Continuing Students /
+    # Non-Continuing Student (+ HighSchoolPersistance from 2024).
+    df <- readxl::read_excel(
+      path = tname,
+      sheet = "6YrGraduationCohortProfile",
+      na = c("*", "N", "NA", "", "-"),
+      guess_max = 10000
+    )
+
+    # Check if HighSchoolPersistance column exists (added in 2024)
+    has_persistence <- "HighSchoolPersistance" %in% names(df) |
+      "StateHighSchoolPersistance" %in% names(df)
+
+    # Standardize column names based on level
+    if (level == "school") {
+      df <- df %>%
+        dplyr::rename(
+          county_id = CountyCode,
+          county_name = CountyName,
+          district_id = DistrictCode,
+          district_name = DistrictName,
+          school_id = SchoolCode,
+          school_name = SchoolName,
+          subgroup = StudentGroup,
+          grad_rate_6yr = Graduates,
+          continuing_rate = `Continuing Students`,
+          non_continuing_rate = `Non-Continuing Student`
+        )
+
+      # Add persistence_rate if available, otherwise calculate or set NA
+      if (has_persistence) {
+        df <- df %>% dplyr::rename(persistence_rate = HighSchoolPersistance)
+      } else {
+        # Calculate persistence = graduates + continuing (not available in early years)
+        df <- df %>% dplyr::mutate(persistence_rate = NA_real_)
+      }
+
+      df <- df %>%
+        dplyr::select(
+          county_id, county_name,
+          district_id, district_name,
+          school_id, school_name,
+          subgroup,
+          grad_rate_6yr, continuing_rate, non_continuing_rate, persistence_rate
+        )
+    } else {
+      # District file doesn't have SchoolCode/SchoolName
+      df <- df %>%
+        dplyr::rename(
+          county_id = CountyCode,
+          county_name = CountyName,
+          district_id = DistrictCode,
+          district_name = DistrictName,
+          subgroup = StudentGroup,
+          grad_rate_6yr = Graduates,
+          continuing_rate = `Continuing Students`,
+          non_continuing_rate = `Non-Continuing Student`
+        )
+
+      # Add persistence_rate if available, otherwise set NA
+      if (has_persistence) {
+        df <- df %>% dplyr::rename(persistence_rate = HighSchoolPersistance)
+      } else {
+        df <- df %>% dplyr::mutate(persistence_rate = NA_real_)
+      }
+
+      df <- df %>%
+        dplyr::mutate(
+          school_id = "999",
+          school_name = "District Total"
+        ) %>%
+        dplyr::select(
+          county_id, county_name,
+          district_id, district_name,
+          school_id, school_name,
+          subgroup,
+          grad_rate_6yr, continuing_rate, non_continuing_rate, persistence_rate
+        )
+    }
   }
 
   # Convert rate columns to numeric
@@ -532,7 +646,7 @@ fetch_6yr_grad_rate <- function(end_year, level = "school") {
 #'
 #' @param level One of "school", "district", or "both". "both" combines
 #'   school and district data. Default is "school".
-#' @return A data frame with all 6-year graduation rate results (2021-2024)
+#' @return A data frame with all 6-year graduation rate results (2021-2025)
 #' @export
 #' @examples
 #' \dontrun{
@@ -546,8 +660,8 @@ fetch_all_6yr_grad_rate <- function(level = "school") {
 
   results <- list()
 
-  # 6-year graduation data available 2021-2024
-  valid_years <- c(2021, 2022, 2023, 2024)
+  # 6-year graduation data available 2021-2025
+  valid_years <- c(2021, 2022, 2023, 2024, 2025)
 
   if (level == "both") {
     for (year in valid_years) {

--- a/R/process_graduation.R
+++ b/R/process_graduation.R
@@ -63,10 +63,13 @@ process_grate <- function(df, end_year) {
     "2011 Adjusted Cohort Grad Rate",
     "2012 Adjusted Cohort Grad Rate",
     "FOUR_YR_GRAD_RATE",
-    "Graduation Rate"
+    "Graduation Rate",
+    # 2024-25 (Cohort2025) renamed the rate column
+    "Adjusted Cohort Graduation Rate"
   )] <- "grad_rate"
-  # 2021+ files use "Cohort Count" and "Graduated" instead of full names
-  names(df)[names(df) %in% c("Four Year Adjusted Cohort Count", "FOUR_YR_ADJ_COHORT_COUNT", "Cohort Count")] <- "cohort_count"
+  # 2021+ files use "Cohort Count" and "Graduated" instead of full names;
+  # 2024-25 (Cohort2025) renamed "Cohort Count" -> "Adjusted Cohort Count"
+  names(df)[names(df) %in% c("Four Year Adjusted Cohort Count", "FOUR_YR_ADJ_COHORT_COUNT", "Cohort Count", "Adjusted Cohort Count")] <- "cohort_count"
   names(df)[names(df) %in% c("Four Year Graduates Count", "GRADUATED_COUNT", "Graduated")] <- "graduated_count"
 
   names(df) <- names(df) %>% tolower()
@@ -321,6 +324,8 @@ grad_file_group_cleanup <- function(group) {
   dplyr::case_when(
     group %in% c("american indian or alaska native", "american_indian") ~ "american indian",
     group %in% c("black or african american") ~ "black",
+    # 2024-25 (Cohort2025) renamed "Hispanic" -> "Hispanic/Latino"
+    group %in% c("hispanic/latino", "hispanic_latino") ~ "hispanic",
     group %in% c(
       "economically_disadvantaged",
       "economically disadvantaged students"
@@ -330,6 +335,9 @@ grad_file_group_cleanup <- function(group) {
     group %in% c("native hawaiian or pacific islander", "pacific_islander", "native_hawaiian") ~ "pacific islander",
     group %in% c("asian, native hawaiian, or pacific islander") ~ "asian",
     group %in% c("students with disabilities", "students_with_disability") ~ "students with disabilities",
+    # 2024-25 (Cohort2025) renamed the total row "Total" -> "All Students";
+    # map to "total" to stay consistent with prior-year files
+    group %in% c("all students", "all_students") ~ "total",
     group %in% c(
       "districtwide", "schoolwide",
       "statewide total", "statewide_total", "statewide",

--- a/man/GCOUNT_VALID_YEARS.Rd
+++ b/man/GCOUNT_VALID_YEARS.Rd
@@ -5,7 +5,7 @@
 \alias{GCOUNT_VALID_YEARS}
 \title{Graduation count valid years}
 \format{
-An object of class \code{integer} of length 27.
+An object of class \code{integer} of length 28.
 }
 \usage{
 GCOUNT_VALID_YEARS

--- a/man/GRATE_4YR_VALID_YEARS.Rd
+++ b/man/GRATE_4YR_VALID_YEARS.Rd
@@ -5,7 +5,7 @@
 \alias{GRATE_4YR_VALID_YEARS}
 \title{4-year graduation rate valid years}
 \format{
-An object of class \code{integer} of length 14.
+An object of class \code{integer} of length 15.
 }
 \usage{
 GRATE_4YR_VALID_YEARS

--- a/man/fetch_6yr_grad_rate.Rd
+++ b/man/fetch_6yr_grad_rate.Rd
@@ -8,7 +8,7 @@ fetch_6yr_grad_rate(end_year, level = "school")
 }
 \arguments{
 \item{end_year}{A school year. Year is the end of the academic year - eg
-2020-21 school year is end_year '2021'. Valid values are 2021-2024.}
+2020-21 school year is end_year '2021'. Valid values are 2021-2025.}
 
 \item{level}{One of "school" or "district". "school" returns school-level
 data, "district" returns district and state-level data.}

--- a/man/fetch_all_6yr_grad_rate.Rd
+++ b/man/fetch_all_6yr_grad_rate.Rd
@@ -11,7 +11,7 @@ fetch_all_6yr_grad_rate(level = "school")
 school and district data. Default is "school".}
 }
 \value{
-A data frame with all 6-year graduation rate results (2021-2024)
+A data frame with all 6-year graduation rate results (2021-2025)
 }
 \description{
 Convenience function to download and combine all available 6-year

--- a/man/fetch_grad_count.Rd
+++ b/man/fetch_grad_count.Rd
@@ -8,7 +8,7 @@ fetch_grad_count(end_year)
 }
 \arguments{
 \item{end_year}{End of the academic year - eg 2006-07 is 2007.
-Valid values are 2012-2024.}
+Valid values are 2012-2025.}
 }
 \value{
 dataframe with grad counts

--- a/man/fetch_grad_rate.Rd
+++ b/man/fetch_grad_rate.Rd
@@ -8,7 +8,7 @@ fetch_grad_rate(end_year, methodology = "4 year")
 }
 \arguments{
 \item{end_year}{End of the academic year - eg 2006-07 is 2007.
-Valid values are 2011-2024.}
+Valid values are 2011-2025.}
 
 \item{methodology}{Character string specifying calculation methodology.
 One of "4 year" or "5 year".}

--- a/man/get_grad_count.Rd
+++ b/man/get_grad_count.Rd
@@ -8,7 +8,7 @@ get_grad_count(end_year)
 }
 \arguments{
 \item{end_year}{End of the academic year - eg 2006-07 is 2007.
-Valid values are 2012-2024.}
+Valid values are 2012-2025.}
 }
 \value{
 dataframe with the number of graduates per school and district

--- a/man/get_grad_rate.Rd
+++ b/man/get_grad_rate.Rd
@@ -8,7 +8,7 @@ get_grad_rate(end_year, methodology)
 }
 \arguments{
 \item{end_year}{End of the academic year - 2011-2012 is 2012.
-Valid values are 2011-2024.}
+Valid values are 2011-2025.}
 
 \item{methodology}{Character string specifying calculation methodology.
 One of "4 year" or "5 year".}

--- a/man/get_raw_grad_file.Rd
+++ b/man/get_raw_grad_file.Rd
@@ -8,7 +8,7 @@ get_raw_grad_file(end_year, methodology = "4 year")
 }
 \arguments{
 \item{end_year}{End of the academic year - eg 2006-07 is 2007.
-Valid values are 1998-2024.}
+Valid values are 1998-2025.}
 
 \item{methodology}{One of c('4 year', '5 year')}
 }

--- a/man/get_spr_6yr_grad_url.Rd
+++ b/man/get_spr_6yr_grad_url.Rd
@@ -7,7 +7,7 @@
 get_spr_6yr_grad_url(end_year, level = "school")
 }
 \arguments{
-\item{end_year}{A school year (2021-2024). Year is the end of the academic
+\item{end_year}{A school year (2021-2025). Year is the end of the academic
 year - eg 2020-21 school year is end_year '2021'.}
 
 \item{level}{One of "school" or "district". Determines which database file

--- a/tests/testthat/test-graduation-year-coverage.R
+++ b/tests/testthat/test-graduation-year-coverage.R
@@ -29,7 +29,8 @@ grate_4yr_pins <- list(
   list(year = 2021, state_rate = 0.906, state_cohort = 106508, state_grads = 96514),
   list(year = 2022, state_rate = 0.909, state_cohort = 106822, state_grads = 97079),
   list(year = 2023, state_rate = 0.911, state_cohort = 106157, state_grads = 96683),
-  list(year = 2024, state_rate = 0.913, state_cohort = 107713, state_grads = 98300)
+  list(year = 2024, state_rate = 0.913, state_cohort = 107713, state_grads = 98300),
+  list(year = 2025, state_rate = 0.918, state_cohort = 110955, state_grads = 101904)
 )
 
 for (spec in grate_4yr_pins) {
@@ -161,7 +162,8 @@ gcount_pins <- list(
   list(year = 2015, state_grads = 95149),
   list(year = 2019, state_grads = 96591),
   list(year = 2020, state_grads = 96084),
-  list(year = 2024, state_grads = 98300)
+  list(year = 2024, state_grads = 98300),
+  list(year = 2025, state_grads = 101904)
 )
 
 for (spec in gcount_pins) {


### PR DESCRIPTION
## Summary

Extends the 4-year and 6-year graduation fetchers to SY2024-25 (`end_year` 2025). NJ DOE published the SY2024-25 graduation files on 2026-05-21 but restructured them (moved headers, renamed sheets/columns/subgroups), so this is a parser change, not just a year bump. Implements Section 3 (Graduation) of `analysis/11-2024-25-coverage-audit.md`. Verified end-to-end against the live NJ DOE files.

## Changes

**`R/config_years.R`** (only the 2 graduation constants; PARCC/ENR/5yr untouched)
- `GRATE_4YR_VALID_YEARS` 2011:2024 -> 2011:2025
- `GCOUNT_VALID_YEARS` 1998:2024 -> 1998:2025

**`R/fetch_graduation.R`**
- `get_raw_grad_file`: year guard 2024 -> 2025, new 2025 4-year branch (file `Cohort2025_4YearAdjustedCohortGraduationRatesbyStudentGroup.xlsx`, `num_skip = 5`)
- `get_grad_count` / `get_grad_rate`: year guards bumped to 2025
- `get_spr_6yr_grad_url` / `fetch_all_6yr_grad_rate`: 2025 added to `valid_years`
- `fetch_6yr_grad_rate`: 2025 reads the renamed `GraduationCohortProfile` sheet (header row 4, filter `CohortType == "6-Year"`), reads `_School`/`_District`/`_State` columns, strips `%` from percent-string rates, coalesces `_District`->`_State` for the statewide row, and normalizes literal `"State"` county/district codes to `99`/`9999` so `is_state` works. Legacy 2017-2024 path unchanged. Download timeout raised above R's 60s default for the large (~368 MB) SPR files.
- `clean_6yr_grad_subgroups`: maps `All Students` -> total population, `Hispanic/Latino` -> hispanic

**`R/process_graduation.R`**
- `process_grate`: adds `Adjusted Cohort Graduation Rate` -> `grad_rate` and `Adjusted Cohort Count` -> `cohort_count` (old names still work)
- `grad_file_group_cleanup`: maps renamed 2025 subgroups (`All Students` -> total, `Hispanic/Latino` -> hispanic)

**Tests:** added 2025 pins to `test-graduation-year-coverage.R`.

## Observed 2025 file structure

- **4-year file:** sheet `Cohort 2025 4 Year Student Grp`, header on row 6 (`skip = 5`). Columns: `County Code`, `County Name`, `District Code`, `District Name`, `School Code`, `School Name`, `Student Group`, `Adjusted Cohort Graduation Rate`, `Adjusted Cohort Count`, `Graduated`. Subgroups renamed `Total` -> `All Students`, `Hispanic` -> `Hispanic/Latino`.
- **6-year (SPR):** sheet renamed `6YrGraduationCohortProfile` -> `GraduationCohortProfile`, header row 4 (`skip = 3`), `CohortType` column with `4-Year`/`5-Year`/`6-Year`. Rate columns gained `_School`/`_District`/`_State` suffixes and are percent strings (`"81.6%"`). Statewide row uses literal `"State"` codes; its `_District` cells are blank (value lives in `_State`).

## Verification (run against live NJ DOE URLs)

| Check | Result |
|-------|--------|
| `fetch_grad_rate(2025, "4 year")` | 12,818 rows; statewide total `grad_rate=0.918`, `cohort=110,955`, `graduated=101,904` |
| `fetch_grad_count(2025)` | 12,818 rows; both count columns populated |
| `fetch_6yr_grad_rate(2025)` (school) | 7,395 school rows; rates 17.8-100, no `%`, 493 charters |
| `fetch_6yr_grad_rate(2025, "district")` | 5,440 rows; statewide total `grad_rate_6yr=93.2`, `persistence_rate=94.2` |
| Regression `fetch_grad_rate(2024, "4 year")` | unchanged: statewide total `grad_rate=0.913`, `cohort=107,713`, `graduated=98,300` |
| Regression `fetch_6yr_grad_rate(2024, "district")` | runs, numeric rates, legacy path untouched |
| `test-graduation-year-coverage.R` (NOT_CRAN) | 123 tests, 0 failures |

Sanity: 2025 statewide 4-yr ACGR 91.8% vs 2024 91.3% (in line with NJ ~91%). 6-yr (93.2%) > 4-yr (91.8%) as expected.

## Follow-ups (out of scope, not introduced here)

- The legacy 2017-2024 6-year path also uses literal `"State"` codes in the SPR file, so `is_state` has always been `FALSE` for those years (pre-existing bug). The new 2025 branch fixes this for 2025 only; the legacy path was left untouched per scope.
- `man/ENR_VALID_YEARS.Rd` is stale on master vs its roxygen source; `document()` wants to regenerate it. Left untouched (owned by the enrollment work).
