### PR TITLE
Fix fetch_6yr_grad_rate fabrication; restore statewide is_state for 2017-2024

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,21 @@
   NJ DOE has used since 2022. The old `gsub("ALG", "ALG0", ...)` step left `GEO`
   unchanged, so `fetch_parcc(year, "GEO", "math")` silently 404'd for 2022-2024.
   Geometry results now fetch for all of 2022-2025.
+* `fetch_6yr_grad_rate()` no longer fabricates suppressed-district rates. The
+  SPR cohort profiles repeat the statewide reference rate in `State:`/`_State`
+  columns on every district row, and the 2025 district path filled those onto
+  ordinary districts whose own rate was blank (suppressed, fewer than 10
+  students) via an unconditional `coalesce(..._District, ..._State)`. For 2024-25
+  this had assigned the statewide subgroup rate to ~2,700 suppressed
+  district-subgroup rows. The fallback to the `State:`/`_State` columns is now
+  restricted to the statewide aggregate row, so suppressed districts stay `NA`.
+* `fetch_6yr_grad_rate()` now flags the statewide aggregate row with `is_state`
+  for 2017-2024 as well, and populates that row's rate. Every SPR cohort profile
+  stores the literal string `"State"` in the statewide row's
+  CountyCode/DistrictCode instead of the numeric `99`/`9999` codes; the
+  normalization that was added for 2025 now runs for all years, and the legacy
+  district path fills the statewide row's rate from the `State:` columns, so the
+  statewide 6-year rate is no longer silently dropped for older years.
 
 ## Known follow-ups
 

--- a/R/fetch_graduation.R
+++ b/R/fetch_graduation.R
@@ -470,7 +470,10 @@ fetch_6yr_grad_rate <- function(end_year, level = "school") {
     } else {
       # District file has no SchoolCode/SchoolName. Real district rows carry
       # their rate in the _District columns; the statewide aggregate row leaves
-      # _District blank and only populates _State, so coalesce District -> State.
+      # _District blank and only populates _State. The _State columns are
+      # repeated on every district row as a reference, so we pull from them ONLY
+      # for the statewide row -- using them as a general fallback would fabricate
+      # the statewide value onto suppressed districts (whose _District is NA).
       df <- df %>%
         dplyr::rename(
           county_id = CountyCode,
@@ -480,10 +483,11 @@ fetch_6yr_grad_rate <- function(end_year, level = "school") {
           subgroup = StudentGroup
         ) %>%
         dplyr::mutate(
-          grad_rate_6yr = dplyr::coalesce(Graduated_District, Graduated_State),
-          continuing_rate = dplyr::coalesce(Continuing_District, Continuing_State),
-          non_continuing_rate = dplyr::coalesce(NonContinuing_District, NonContinuing_State),
-          persistence_rate = dplyr::coalesce(Persisting_District, Persisting_State),
+          .is_state_row = !is.na(county_id) & county_id == "State",
+          grad_rate_6yr = dplyr::if_else(.is_state_row, Graduated_State, Graduated_District),
+          continuing_rate = dplyr::if_else(.is_state_row, Continuing_State, Continuing_District),
+          non_continuing_rate = dplyr::if_else(.is_state_row, NonContinuing_State, NonContinuing_District),
+          persistence_rate = dplyr::if_else(.is_state_row, Persisting_State, Persisting_District),
           school_id = "999",
           school_name = "District Total"
         ) %>%
@@ -501,16 +505,6 @@ fetch_6yr_grad_rate <- function(end_year, level = "school") {
     for (col in rate_cols) {
       df[[col]] <- gsub("%", "", as.character(df[[col]]), fixed = TRUE)
     }
-
-    # In the 2024-25 GraduationCohortProfile sheet the statewide row carries the
-    # literal string "State" in CountyCode/DistrictCode rather than the numeric
-    # 99/9999 codes used elsewhere. Normalize so the aggregation flags below
-    # (is_state, is_district, ...) classify it correctly.
-    df <- df %>%
-      dplyr::mutate(
-        district_id = dplyr::if_else(district_id == "State", "9999", district_id),
-        county_id = dplyr::if_else(county_id == "State", "99", county_id)
-      )
   } else {
     # 2017-2024: legacy "6YrGraduationCohortProfile" sheet, headers on row 1,
     # numeric rate columns named Graduates / Continuing Students /
@@ -559,30 +553,41 @@ fetch_6yr_grad_rate <- function(end_year, level = "school") {
           grad_rate_6yr, continuing_rate, non_continuing_rate, persistence_rate
         )
     } else {
-      # District file doesn't have SchoolCode/SchoolName
+      # District/state file: no SchoolCode/SchoolName. The statewide aggregate
+      # row (CountyCode == "State") leaves the base rate columns blank and stores
+      # its values in parallel "State: <col>" columns -- but those "State:"
+      # columns are repeated on *every* district row as a reference, so we pull
+      # from them ONLY for the statewide row. Filling NA base values for ordinary
+      # (suppressed) districts from the "State:" columns would fabricate data.
+      is_state_row <- !is.na(df$CountyCode) & df$CountyCode == "State"
+      fill_state <- function(base_col, state_col) {
+        base <- df[[base_col]]
+        if (state_col %in% names(df)) {
+          dplyr::if_else(is_state_row, df[[state_col]], base)
+        } else {
+          base
+        }
+      }
+
       df <- df %>%
+        dplyr::mutate(
+          grad_rate_6yr = fill_state("Graduates", "State: Graduates"),
+          continuing_rate = fill_state("Continuing Students", "State: Continuing Students"),
+          non_continuing_rate = fill_state("Non-Continuing Student", "State: Non-Continuing Student"),
+          persistence_rate = if (has_persistence) {
+            fill_state("HighSchoolPersistance", "State: HighSchoolPersistance")
+          } else {
+            NA_real_
+          },
+          school_id = "999",
+          school_name = "District Total"
+        ) %>%
         dplyr::rename(
           county_id = CountyCode,
           county_name = CountyName,
           district_id = DistrictCode,
           district_name = DistrictName,
-          subgroup = StudentGroup,
-          grad_rate_6yr = Graduates,
-          continuing_rate = `Continuing Students`,
-          non_continuing_rate = `Non-Continuing Student`
-        )
-
-      # Add persistence_rate if available, otherwise set NA
-      if (has_persistence) {
-        df <- df %>% dplyr::rename(persistence_rate = HighSchoolPersistance)
-      } else {
-        df <- df %>% dplyr::mutate(persistence_rate = NA_real_)
-      }
-
-      df <- df %>%
-        dplyr::mutate(
-          school_id = "999",
-          school_name = "District Total"
+          subgroup = StudentGroup
         ) %>%
         dplyr::select(
           county_id, county_name,
@@ -610,6 +615,18 @@ fetch_6yr_grad_rate <- function(end_year, level = "school") {
   # Remove rows without county_id
   df <- df %>%
     dplyr::filter(!is.na(county_id))
+
+  # Every year's SPR cohort profile -- the legacy "6YrGraduationCohortProfile"
+  # (2017-2024) and the 2024-25 "GraduationCohortProfile" -- puts the literal
+  # string "State" in the CountyCode/DistrictCode of the statewide aggregate row
+  # rather than the numeric 99/9999 codes used elsewhere. Normalize so the
+  # aggregation flags below classify the statewide row as is_state (it was
+  # silently FALSE for 2017-2024 before this).
+  df <- df %>%
+    dplyr::mutate(
+      district_id = dplyr::if_else(district_id == "State", "9999", district_id),
+      county_id = dplyr::if_else(county_id == "State", "99", county_id)
+    )
 
   # Add aggregation flags
   df <- df %>%

--- a/man/ENR_VALID_YEARS.Rd
+++ b/man/ENR_VALID_YEARS.Rd
@@ -4,15 +4,21 @@
 \name{ENR_VALID_YEARS}
 \alias{ENR_VALID_YEARS}
 \title{Enrollment data valid years
-Note: 1999 data was removed from NJ DOE website}
+Note: 1999 (1998-99 school year) is the earliest file NJ DOE still hosts,
+at enr/enr99/enrollment_9899.zip. Comment in this file used to claim 1999
+was removed, but the ZIP is still served and now parses through
+process_enr() after the split_enr_cols() ordering fix.}
 \format{
-An object of class \code{integer} of length 27.
+An object of class \code{integer} of length 28.
 }
 \usage{
 ENR_VALID_YEARS
 }
 \description{
 Enrollment data valid years
-Note: 1999 data was removed from NJ DOE website
+Note: 1999 (1998-99 school year) is the earliest file NJ DOE still hosts,
+at enr/enr99/enrollment_9899.zip. Comment in this file used to claim 1999
+was removed, but the ZIP is still served and now parses through
+process_enr() after the split_enr_cols() ordering fix.
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary

Follow-up to the SY2024-25 graduation coverage work (#242). While fixing the
known pre-existing bug (the legacy 6-year `is_state` flag was always FALSE for
2017-2024), I found and fixed a **data-fabrication bug** in the just-merged 2025
path.

## The fabrication bug (2025 district path)

The SPR cohort profiles repeat the statewide reference rate in `_State` / `State:`
columns on **every** district row, and the 2025 district path used an
unconditional `coalesce(Graduated_District, Graduated_State)`. For districts
whose own rate is blank (suppressed, fewer than 10 students), the coalesce fell
back to the statewide value, assigning the statewide subgroup rate to ~2,700
suppressed district-subgroup rows.

Verified against the live 2024-25 district file: e.g. Atlantic City's "American
Indian" 6-year rate was showing 91.5% (the statewide American Indian value), not
Atlantic City's own (suppressed) value.

**Fix:** the fallback to the `_State` columns is now restricted to the statewide
aggregate row (`county_id == "State"`). Suppressed districts stay `NA`.

## The legacy is_state fix (2017-2024)

Every SPR cohort profile stores the literal string `"State"` in the statewide
row's County/District code columns instead of `99`/`9999`. That normalization
(added for 2025) now runs for all years, and the legacy district path fills the
statewide row's rate from the repeated `State:` columns (statewide-row-only, same
non-fabrication guard). So `is_state` and the statewide 6-year rate work for
older years too.

## Live verification

| Check | Result |
|-------|--------|
| `fetch_6yr_grad_rate(2024, "district")` is_state | 17 subgroup rows (was 0); statewide total 93.2%, persistence 94.2% |
| 2024 suppressed districts | 2,688 kept `NA` (not fabricated); Atlantic City total = 79.4% (own value) |
| `fetch_6yr_grad_rate(2025, "district")` is_state | 17 subgroup rows, range 68.8-97.9% |
| 2025 suppressed districts | 2,693 now `NA` (was fabricated to statewide); Atlantic City total = 84.6% preserved |
| Package | `devtools::load_all()` clean |

Also regenerates the stale `man/ENR_VALID_YEARS.Rd` (roxygen drift from #240).

A draft note to NJ DOE about the data issues on their end (malformed AP/IB sheet,
missing postsecondary file, no standalone 5-year file, etc.) is kept locally in
`analysis/` (gitignored).