### PR TITLE
Extend SPR 2024-25 fetchers backward to earliest available year

### DIFF
--- a/R/fetch_spr.R
+++ b/R/fetch_spr.R
@@ -1963,19 +1963,23 @@ fetch_spr_essa_status_counts <- function(end_year) {
 
 
 # ==============================================================================
-# Graduation Pathways, Home-Language Enrollment, and NAEP (2024-25)
+# Graduation Pathways, Home-Language Enrollment, and NAEP
 # ==============================================================================
 #
-# Three further sheets that are new (or newly structured) in the redesigned
-# 2024-25 (end_year 2025) SPR databases:
+# Three sheets first exposed via the redesigned 2024-25 databases and since
+# extended backward to the earliest pre-redesign year each one exists:
 #
 #   GraduationPathways       -> % of graduates meeting the requirement by pathway
-#   EnrollmentByHomeLanguage -> enrollment share by home language
+#                               (2018-2022, 2024-2025; absent SY2016-17/SY2022-23)
+#   EnrollmentByHomeLanguage -> enrollment share by home language (2018-2025)
 #   NAEP (District/State DB) -> NAEP 4th/8th-grade reading & math achievement
+#                               (2017-2025; legacy layout mapped to 2025 shape)
 #
 # GraduationPathways and EnrollmentByHomeLanguage carry the standard CDS layout
 # and route through fetch_spr_data(). NAEP is a state/national summary table
 # with no county/district/school identifiers, so it uses a lighter raw reader.
+# Pre-2025 column names are harmonized to the redesigned shape inside each
+# fetcher; see the per-function docs for the exact mapping.
 #
 # ==============================================================================
 
@@ -2054,11 +2058,19 @@ fetch_spr_sheet_raw <- function(sheet_name, end_year, level = "district") {
 #' }
 #' Percentages are returned numeric (suppressed cells become \code{NA}).
 #'
-#' \strong{Supported years:} only \code{end_year >= 2025} (the redesigned
-#' SY2024-25 SPR). Earlier databases do not include this sheet.
+#' \strong{Supported years:} 2018-2022, 2024, and 2025. The
+#' \code{GraduationPathways} sheet is present in those SPR databases (it is
+#' \strong{absent} from the SY2016-17 and SY2022-23 databases, which therefore
+#' error). Before the 2024-25 redesign the columns were named slightly
+#' differently (\code{ELA/Math}, \code{PARCCAssessment}/\code{StatewideAssessment},
+#' \code{SubstituteCompetency}, \code{PortfolioAppealsProcess},
+#' \code{AlternateReqIEP}); this function harmonizes them to the redesigned
+#' names and uppercases the subject label. The COVID-era executive-order waiver
+#' column present in the 2020 and 2021 sheets is not part of the four-pathway
+#' schema and is dropped.
 #'
-#' @param end_year A school year. Only \code{2025} (SY2024-25) and later are
-#'   supported.
+#' @param end_year A school year (2018-2022, 2024, or 2025). Year is the end of
+#'   the academic year - e.g. the 2020-21 school year is \code{end_year} 2021.
 #' @param level One of \code{"school"} or \code{"district"}.
 #'
 #' @return Data frame with entity identifiers, school_year, subject, the four
@@ -2070,6 +2082,9 @@ fetch_spr_sheet_raw <- function(sheet_name, end_year, level = "district") {
 #' \dontrun{
 #' # School-level graduation pathways
 #' gp <- fetch_spr_grad_pathways(2025)
+#'
+#' # The same pathway mix back to SY2017-18
+#' gp_2018 <- fetch_spr_grad_pathways(2018)
 #'
 #' # Statewide ELA pathway mix
 #' library(dplyr)
@@ -2085,7 +2100,20 @@ fetch_spr_sheet_raw <- function(sheet_name, end_year, level = "district") {
 #'   select(district_name, school_name, portfolio_appeals)
 #' }
 fetch_spr_grad_pathways <- function(end_year, level = "school") {
-  spr_require_redesign(end_year, "graduation pathways data")
+  if (end_year < 2018) {
+    stop(
+      "graduation pathways data is available for end_year >= 2018 (the ",
+      "GraduationPathways sheet is absent from the SY2016-17 SPR database).",
+      call. = FALSE
+    )
+  }
+  if (end_year == 2023) {
+    stop(
+      "graduation pathways data is not available for end_year 2023 - the ",
+      "GraduationPathways sheet is absent from the SY2022-23 SPR database.",
+      call. = FALSE
+    )
+  }
 
   df <- fetch_spr_data("GraduationPathways", end_year, level)
   df <- filter_spr_to_year(df, end_year)
@@ -2094,6 +2122,31 @@ fetch_spr_grad_pathways <- function(end_year, level = "school") {
   # direct name assignment to avoid a spurious global-variable NOTE).
   names(df)[names(df) == "alternate_requirementsin_iep"] <-
     "alternate_requirements_in_iep"
+
+  # Harmonize the pre-2025 column names to the redesigned (2024-25) names. Each
+  # rename only fires when the legacy column is present and the target is not,
+  # so the 2025 layout passes through untouched.
+  legacy_renames <- c(
+    subject = "ela_math",
+    # "PARCCAssessment" (2018) snake-cases to a single token (no underscore).
+    statewide_assessment = "parccassessment",
+    substitute_competency_test = "substitute_competency",
+    portfolio_appeals = "portfolio_appeals_process",
+    alternate_requirements_in_iep = "alternate_req_iep"
+  )
+  for (new_nm in names(legacy_renames)) {
+    old_nm <- legacy_renames[[new_nm]]
+    if (old_nm %in% names(df) && !new_nm %in% names(df)) {
+      names(df)[names(df) == old_nm] <- new_nm
+    }
+  }
+
+  # The legacy ELA/Math column carries lowercase labels; uppercase them to match
+  # the redesigned Subject column ("ELA", "Math").
+  if ("subject" %in% names(df)) {
+    df$subject[df$subject == "ela"] <- "ELA"
+    df$subject[df$subject == "math"] <- "Math"
+  }
 
   pathway_cols <- intersect(
     c("statewide_assessment", "substitute_competency_test",
@@ -2129,11 +2182,14 @@ fetch_spr_grad_pathways <- function(end_year, level = "school") {
 #' \code{percent_of_students} is returned numeric on a 0-100 scale (suppressed
 #' cells become \code{NA}).
 #'
-#' \strong{Supported years:} only \code{end_year >= 2025} (the redesigned
-#' SY2024-25 SPR). Earlier databases do not include this sheet.
+#' \strong{Supported years:} \code{end_year >= 2018}. The
+#' \code{EnrollmentByHomeLanguage} sheet is present back to SY2017-18 with an
+#' identical layout (the 2024-25 redesign only added a \code{SchoolYear} column,
+#' handled transparently). The SY2016-17 sheet omits the county/district/school
+#' name columns and is not supported.
 #'
-#' @param end_year A school year. Only \code{2025} (SY2024-25) and later are
-#'   supported.
+#' @param end_year A school year (2018-2025). Year is the end of the academic
+#'   year - e.g. the 2020-21 school year is \code{end_year} 2021.
 #' @param level One of \code{"school"} or \code{"district"}.
 #'
 #' @return Data frame with entity identifiers, school_year, home_language,
@@ -2145,6 +2201,9 @@ fetch_spr_grad_pathways <- function(end_year, level = "school") {
 #' \dontrun{
 #' # School-level home-language shares
 #' hl <- fetch_spr_home_language(2025)
+#'
+#' # The same breakdown back to SY2017-18
+#' hl_2018 <- fetch_spr_home_language(2018)
 #'
 #' # Statewide home-language distribution
 #' library(dplyr)
@@ -2160,7 +2219,14 @@ fetch_spr_grad_pathways <- function(end_year, level = "school") {
 #'   select(district_name, school_name, percent_of_students)
 #' }
 fetch_spr_home_language <- function(end_year, level = "school") {
-  spr_require_redesign(end_year, "SPR home-language enrollment data")
+  if (end_year < 2018) {
+    stop(
+      "SPR home-language enrollment data is available for end_year >= 2018. ",
+      "The SY2016-17 EnrollmentByHomeLanguage sheet omits the ",
+      "county/district/school name columns.",
+      call. = FALSE
+    )
+  }
 
   df <- fetch_spr_data("EnrollmentByHomeLanguage", end_year, level)
   df <- filter_spr_to_year(df, end_year)
@@ -2200,12 +2266,20 @@ fetch_spr_home_language <- function(end_year, level = "school") {
 #' given periodically, so multiple years appear). The four achievement-level
 #' columns are returned numeric on a 0-100 scale.
 #'
-#' \strong{Supported years:} only \code{end_year >= 2025} (the redesigned
-#' SY2024-25 SPR). Always reads the District/State database (the School database
-#' has no NAEP sheet).
+#' \strong{Supported years:} \code{end_year >= 2017}. Always reads the
+#' District/State database (the School database has no NAEP sheet). Before the
+#' 2024-25 redesign the sheet used a leaner layout (\code{Year}, \code{Test},
+#' \code{Grade} and the four achievement levels) with no student-group
+#' breakdown; this function maps it to the redesigned shape: \code{Year ->
+#' test_year}, \code{Test -> subject}, the legacy \code{"State (NJ)"} label is
+#' normalized to \code{"New Jersey"}, and \code{student_group} is set to the
+#' constant \code{"All Students"} (the legacy sheet reports the all-students
+#' summary only; the per-subgroup breakdown was added in 2024-25).
 #'
-#' @param end_year A school year. Only \code{2025} (SY2024-25) and later are
-#'   supported.
+#' @param end_year A school year (2017-2025). Year is the end of the academic
+#'   year - e.g. the 2024-25 school year is \code{end_year} 2025. Note this is
+#'   the SPR publication year, not the NAEP administration year (see
+#'   \code{test_year}).
 #'
 #' @return Data frame with end_year (the SPR publication year), test_year (the
 #'   NAEP administration year), state_nation, subject, grade, student_group, and
@@ -2218,6 +2292,9 @@ fetch_spr_home_language <- function(end_year, level = "school") {
 #' # NAEP results as published in the 2024-25 SPR
 #' naep <- fetch_spr_naep(2025)
 #'
+#' # NAEP as published in an earlier SPR (all-students summary only)
+#' naep_2024 <- fetch_spr_naep(2024)
+#'
 #' # New Jersey vs. the nation, Grade 4 Math, most recent administration
 #' library(dplyr)
 #' fetch_spr_naep(2025) %>%
@@ -2227,9 +2304,29 @@ fetch_spr_home_language <- function(end_year, level = "school") {
 #'   select(state_nation, below_basic, basic, proficient, advanced)
 #' }
 fetch_spr_naep <- function(end_year) {
-  spr_require_redesign(end_year, "NAEP data")
+  if (end_year < 2017) {
+    stop("NAEP data is available for end_year >= 2017.", call. = FALSE)
+  }
 
   df <- fetch_spr_sheet_raw("NAEP", end_year, level = "district")
+
+  # Pre-2025 layout: Year | StateNation | Test | Grade | <achievement levels>,
+  # with no Subject or StudentGroup column. Map it onto the redesigned shape.
+  if (!"test_year" %in% names(df) && "year" %in% names(df)) {
+    df <- dplyr::rename(df, test_year = "year")
+  }
+  if (!"subject" %in% names(df) && "test" %in% names(df)) {
+    df <- dplyr::rename(df, subject = "test")
+  }
+  if (!"student_group" %in% names(df)) {
+    # The legacy sheet reports the all-students summary only (the per-subgroup
+    # breakdown was added in the 2024-25 redesign).
+    df$student_group <- "All Students"
+  }
+  # Normalize the legacy state label to the redesigned form.
+  if ("state_nation" %in% names(df)) {
+    df$state_nation[df$state_nation == "State (NJ)"] <- "New Jersey"
+  }
 
   # Drop the trailing "end of worksheet" sentinel and any all-blank rows.
   df <- df %>%
@@ -2256,19 +2353,23 @@ fetch_spr_naep <- function(end_year) {
 
 
 # ==============================================================================
-# Expanded Staff Sheets (2024-25)
+# Expanded Staff Sheets
 # ==============================================================================
 #
 # The redesigned 2024-25 (end_year 2025) SPR databases broke staffing detail out
-# across several new sheets. The fetchers below expose them:
+# across several sheets. The fetchers below expose them; the "years" note marks
+# how far each one has been extended backward into the pre-redesign databases
+# (see each function's docs for the mapping / granularity caveats):
 #
-#   AdministratorsExperience       -> administrator experience distribution
-#   StaffCounts                    -> staff counts by role
-#   TeachersAdminsDemoSubjectArea  -> teacher demographics by subject area
+#   AdministratorsExperience       -> administrator experience distribution (2025+)
+#   StaffCounts                    -> staff counts by role (2021+)
+#   TeachersAdminsDemoSubjectArea  -> teacher demographics by subject area (2025+)
 #   TeachersAdminsEducation        -> teacher/admin highest-degree distribution
+#                                     (2018+; legacy TeachersAdminsLevelOfEducation)
 #   TeachersAdminsOneYearRetention -> one-year retention rates
-#   TeacherExperienceSubjArea      -> teacher experience/degree by subject area
-#   StatewideEducatorEquity (D/S)  -> statewide out-of-field / equity metrics
+#                                     (2018+ district; 2025+ school)
+#   TeacherExperienceSubjArea      -> teacher experience/degree by subject area (2025+)
+#   StatewideEducatorEquity (D/S)  -> statewide out-of-field / equity metrics (2025+)
 #
 # A note on privacy ranges: for the by-subject-area demographic sheet, NJ DOE
 # reports small-cell percentages as ranges (e.g. "70-80%", "<=10%"). Those
@@ -2368,10 +2469,12 @@ fetch_spr_admin_experience <- function(end_year, level = "school") {
 #' returned numeric (thousands commas stripped; cells reading \dQuote{There is no
 #' data available for this school year.} set to \code{NA}).
 #'
-#' \strong{Supported years:} only \code{end_year >= 2025}.
+#' \strong{Supported years:} \code{end_year >= 2021}. The \code{StaffCounts}
+#' sheet first appears in the SY2020-21 SPR and has the same layout through the
+#' redesign. Earlier databases have no equivalent sheet.
 #'
-#' @param end_year A school year. Only \code{2025} (SY2024-25) and later are
-#'   supported.
+#' @param end_year A school year (2021-2025). Year is the end of the academic
+#'   year - e.g. the 2020-21 school year is \code{end_year} 2021.
 #' @param level One of \code{"school"} or \code{"district"}.
 #'
 #' @return Data frame with entity identifiers, staff_category, the three staff
@@ -2382,6 +2485,9 @@ fetch_spr_admin_experience <- function(end_year, level = "school") {
 #' @examples
 #' \dontrun{
 #' staff <- fetch_spr_staff_counts(2025)
+#'
+#' # The same counts back to SY2020-21
+#' staff_2021 <- fetch_spr_staff_counts(2021)
 #'
 #' # Teacher counts by school
 #' library(dplyr)
@@ -2395,7 +2501,13 @@ fetch_spr_admin_experience <- function(end_year, level = "school") {
 #'   select(staff_category, state_total_staff_members)
 #' }
 fetch_spr_staff_counts <- function(end_year, level = "school") {
-  spr_require_redesign(end_year, "staff counts data")
+  if (end_year < 2021) {
+    stop(
+      "staff counts data is available for end_year >= 2021. The StaffCounts ",
+      "sheet first appears in the SY2020-21 School Performance Reports.",
+      call. = FALSE
+    )
+  }
 
   df <- fetch_spr_data("StaffCounts", end_year, level)
 
@@ -2484,10 +2596,16 @@ fetch_spr_staff_demo_subject <- function(end_year, level = "school") {
 #' (suppressed/non-numeric cells, including the administrator note that
 #' administrators must hold a Master's or higher, set to \code{NA}).
 #'
-#' \strong{Supported years:} only \code{end_year >= 2025}.
+#' \strong{Supported years:} \code{end_year >= 2018}. Before the 2024-25
+#' redesign this sheet was named \code{TeachersAdminsLevelOfEducation}; the
+#' Bachelor's/Master's/Doctoral layout is identical from SY2017-18 on (this
+#' function selects the right sheet by year). The legacy sheet labels the
+#' administrator row \code{"Admin"}; it is normalized to \code{"Administrators"}
+#' for cross-year consistency. The SY2016-17 sheet uses a different long-format
+#' layout and is not supported.
 #'
-#' @param end_year A school year. Only \code{2025} (SY2024-25) and later are
-#'   supported.
+#' @param end_year A school year (2018-2025). Year is the end of the academic
+#'   year - e.g. the 2020-21 school year is \code{end_year} 2021.
 #' @param level One of \code{"school"} or \code{"district"}.
 #'
 #' @return Data frame with entity identifiers, teachers_admins, bachelors,
@@ -2499,6 +2617,9 @@ fetch_spr_staff_demo_subject <- function(end_year, level = "school") {
 #' \dontrun{
 #' edu <- fetch_spr_staff_education(2025)
 #'
+#' # The same degree distribution back to SY2017-18
+#' edu_2018 <- fetch_spr_staff_education(2018)
+#'
 #' # Share of teachers with a Master's degree, by school
 #' library(dplyr)
 #' fetch_spr_staff_education(2025) %>%
@@ -2506,9 +2627,26 @@ fetch_spr_staff_demo_subject <- function(end_year, level = "school") {
 #'   select(district_name, school_name, masters, doctoral)
 #' }
 fetch_spr_staff_education <- function(end_year, level = "school") {
-  spr_require_redesign(end_year, "teacher/administrator education data")
+  if (end_year < 2018) {
+    stop(
+      "teacher/administrator education data is available for end_year >= 2018. ",
+      "The SY2016-17 sheet uses a different long-format layout.",
+      call. = FALSE
+    )
+  }
 
-  df <- fetch_spr_data("TeachersAdminsEducation", end_year, level)
+  # The sheet was renamed TeachersAdminsLevelOfEducation -> TeachersAdminsEducation
+  # in the 2024-25 redesign; the degree-column layout is otherwise identical.
+  sheet_name <- spr_sheet_for_year(
+    end_year, "TeachersAdminsLevelOfEducation", "TeachersAdminsEducation"
+  )
+  df <- fetch_spr_data(sheet_name, end_year, level)
+
+  # Legacy sheets label the administrator row "Admin"; the 2024-25 sheet uses
+  # "Administrators". Normalize so a single value works across all years.
+  if ("teachers_admins" %in% names(df)) {
+    df$teachers_admins[df$teachers_admins == "Admin"] <- "Administrators"
+  }
 
   for (col in intersect(c("bachelors", "masters", "doctoral"), names(df))) {
     df[[col]] <- spr_value_numeric(df[[col]])
@@ -2529,10 +2667,17 @@ fetch_spr_staff_education <- function(end_year, level = "school") {
 #' \code{retention_pct_state} are returned numeric percentages (suppressed cells
 #' set to \code{NA}).
 #'
-#' \strong{Supported years:} only \code{end_year >= 2025}.
+#' \strong{Supported years:} \code{level = "district"} is supported for
+#' \code{end_year >= 2018}; \code{level = "school"} only for
+#' \code{end_year >= 2025}. The retention measure is reported at
+#' district/state granularity (no \code{SchoolCode}) in every SPR database
+#' through SY2023-24; the 2024-25 redesign was the first to add per-school
+#' retention rows. For earlier years, use \code{level = "district"}. (The
+#' SY2016-17 sheet additionally omits entity-name columns and is not supported.)
 #'
-#' @param end_year A school year. Only \code{2025} (SY2024-25) and later are
-#'   supported.
+#' @param end_year A school year. \code{level = "district"} accepts 2018-2025;
+#'   \code{level = "school"} accepts 2025 only. Year is the end of the academic
+#'   year - e.g. the 2020-21 school year is \code{end_year} 2021.
 #' @param level One of \code{"school"} or \code{"district"}.
 #'
 #' @return Data frame with entity identifiers, teachers_admins,
@@ -2550,9 +2695,26 @@ fetch_spr_staff_education <- function(end_year, level = "school") {
 #'   filter(is_district, teachers_admins == "Teachers") %>%
 #'   slice_min(retention_pct_district, n = 10) %>%
 #'   select(district_name, retention_pct_district, retention_pct_state)
+#'
+#' # District/state retention back to SY2017-18
+#' ret_2018 <- fetch_spr_staff_retention(2018, level = "district")
 #' }
 fetch_spr_staff_retention <- function(end_year, level = "school") {
-  spr_require_redesign(end_year, "staff retention data")
+  if (end_year < 2025 && level == "school") {
+    stop(
+      "school-level staff retention is available only for end_year >= 2025. ",
+      "Through SY2023-24 the TeachersAdminsOneYearRetention sheet is reported ",
+      "at district/state granularity - use level = 'district' for earlier years.",
+      call. = FALSE
+    )
+  }
+  if (end_year < 2018) {
+    stop(
+      "staff retention data is available for end_year >= 2018. The SY2016-17 ",
+      "sheet omits entity-name columns.",
+      call. = FALSE
+    )
+  }
 
   df <- fetch_spr_data("TeachersAdminsOneYearRetention", end_year, level)
 

--- a/dev-docs/spr-coverage-gap.md
+++ b/dev-docs/spr-coverage-gap.md
@@ -23,28 +23,45 @@ This doc catalogues every uncovered sheet by domain, flags priority, and propose
 
 ## Already Implemented
 
-The Tier 1 and Tier 2 shortlist below was implemented in 2026-05 (PRs #247, #250, #251, #252). All are gated to `end_year >= 2025` and error rather than guess a mapping for earlier years.
+The Tier 1 and Tier 2 shortlist below was implemented in 2026-05 (PRs #247, #250, #251, #252). The **Years** column reflects the backfill work (below): six fetchers were extended to the earliest year their source sheet exists with a structure that maps to the redesigned shape without fabrication; the rest stay gated at `end_year >= 2025` and error rather than guess a mapping for earlier years.
 
-| Sheet(s) | Fetcher | PR |
-|---|---|---|
-| StudentGrowthTrends / StudentGrowthbyGrade / StudentGrowthByPerformLevel | `fetch_sgp(type=)` | #247 |
-| ProficiencyTargets / GrowthTargets / GraduationTargets / ProgresstowardELPTargets / ChronicAbsenteeismTargets / HSPersistenceTargets | `fetch_spr_essa_targets(indicator=)` | #250 |
-| AccountabilitySummative | `fetch_spr_accountability_summative()` | #250 |
-| TSIIdentification | `fetch_spr_tsi()` | #250 |
-| ESSAAccountabilityStatusList (district) | `fetch_essa_status(level="district")` | #248 |
-| ESSAAccountabilityStatusCounts | `fetch_spr_essa_status_counts()` | #250 |
-| GraduationPathways | `fetch_spr_grad_pathways()` | #251 |
-| EnrollmentByHomeLanguage | `fetch_spr_home_language()` | #251 |
-| NAEP (district/state) | `fetch_spr_naep()` | #251 |
-| AdministratorsExperience | `fetch_spr_admin_experience()` | #252 |
-| StaffCounts | `fetch_spr_staff_counts()` | #252 |
-| TeachersAdminsDemoSubjectArea | `fetch_spr_staff_demo_subject()` | #252 |
-| TeachersAdminsEducation | `fetch_spr_staff_education()` | #252 |
-| TeachersAdminsOneYearRetention | `fetch_spr_staff_retention()` | #252 |
-| TeacherExperienceSubjArea | `fetch_spr_teacher_exp_subject()` | #252 |
-| StatewideEducatorEquity (district/state) | `fetch_spr_educator_equity()` | #252 |
+| Sheet(s) | Fetcher | Years | PR |
+|---|---|---|---|
+| StudentGrowthTrends / StudentGrowthbyGrade / StudentGrowthByPerformLevel | `fetch_sgp(type=)` | 2025+ | #247 |
+| ProficiencyTargets / GrowthTargets / GraduationTargets / ProgresstowardELPTargets / ChronicAbsenteeismTargets / HSPersistenceTargets | `fetch_spr_essa_targets(indicator=)` | 2025+ | #250 |
+| AccountabilitySummative | `fetch_spr_accountability_summative()` | 2025+ | #250 |
+| TSIIdentification | `fetch_spr_tsi()` | 2025+ | #250 |
+| ESSAAccountabilityStatusList (district) | `fetch_essa_status(level="district")` | 2025+ | #248 |
+| ESSAAccountabilityStatusCounts | `fetch_spr_essa_status_counts()` | 2025+ | #250 |
+| GraduationPathways | `fetch_spr_grad_pathways()` | **2018-2022, 2024-2025** | #251, backfill |
+| EnrollmentByHomeLanguage | `fetch_spr_home_language()` | **2018-2025** | #251, backfill |
+| NAEP (district/state) | `fetch_spr_naep()` | **2017-2025** | #251, backfill |
+| AdministratorsExperience | `fetch_spr_admin_experience()` | 2025+ | #252 |
+| StaffCounts | `fetch_spr_staff_counts()` | **2021-2025** | #252, backfill |
+| TeachersAdminsDemoSubjectArea | `fetch_spr_staff_demo_subject()` | 2025+ | #252 |
+| TeachersAdminsEducation (legacy: TeachersAdminsLevelOfEducation) | `fetch_spr_staff_education()` | **2018-2025** | #252, backfill |
+| TeachersAdminsOneYearRetention | `fetch_spr_staff_retention()` | **2018-2025 (district); 2025+ (school)** | #252, backfill |
+| TeacherExperienceSubjArea | `fetch_spr_teacher_exp_subject()` | 2025+ | #252 |
+| StatewideEducatorEquity (district/state) | `fetch_spr_educator_equity()` | 2025+ | #252 |
 
 Notes: NAEP and StatewideEducatorEquity carry no CDS codes (state/national summary tables), so they read through the internal `fetch_spr_sheet_raw()` helper (no CDS/flag machinery). `fetch_spr_staff_demo_subject()` deliberately keeps its racial/ethnic and gender composition columns as character — NJ DOE reports small-cell percentages as privacy-protected ranges (e.g. `"70-80%"`), and coercing them to a single number would fabricate precision.
+
+### Backfill to pre-redesign databases (2026-05)
+
+The 14 redesign fetchers were all originally gated at `end_year >= 2025`. An audit of
+the 2017-2024 workbooks (`scratch/spr-backfill/`) found that several target sheets exist
+in earlier databases. Each fetcher was extended to its real first year:
+
+| Fetcher | Backfilled to | How |
+|---|---|---|
+| `fetch_spr_home_language()` | 2018 | Same sheet; identical columns minus the 2025-only `SchoolYear`. 2017 omits name columns. |
+| `fetch_spr_staff_counts()` | 2021 | `StaffCounts` first appears SY2020-21; identical columns. |
+| `fetch_spr_staff_education()` | 2018 | Sheet renamed; reads legacy `TeachersAdminsLevelOfEducation`. Legacy `Admin` label normalized to `Administrators`. 2017 is long-format. |
+| `fetch_spr_staff_retention()` | 2018 (district only) | Identical columns, but the measure is district-granularity (no `SchoolCode`) before 2025; school-level rows are 2025+. |
+| `fetch_spr_naep()` | 2017 | Legacy layout (`Year`/`Test`/`Grade`, no subgroup) mapped: `Year->test_year`, `Test->subject`, `"State (NJ)"->"New Jersey"`, `student_group="All Students"` (legacy is all-students only). |
+| `fetch_spr_grad_pathways()` | 2018-2022, 2024 | Legacy column names harmonized (`ELA/Math->subject` uppercased; `PARCCAssessment`/`SubstituteCompetency`/`PortfolioAppealsProcess`/`AlternateReqIEP` -> redesigned names; COVID waiver column dropped). **Absent in SY2016-17 and SY2022-23** (those years error). |
+
+**Confirmed 2025-only (gate retained):** `fetch_spr_essa_targets` (×6), `fetch_spr_accountability_summative`, `fetch_spr_tsi`, `fetch_spr_essa_status_counts`, `fetch_spr_staff_demo_subject`, `fetch_spr_teacher_exp_subject` — their sheets are absent from every 2017-2024 workbook. `fetch_spr_admin_experience` exists earlier but across four incompatible layouts (granularity + column-name churn); `fetch_spr_educator_equity` exists earlier but on a different scale (legacy percentages vs 2025 proportions) and without the `Classes Included` dimension. Forcing either into the 2025 shape would mis-scale or fabricate, so both stay gated.
 
 The remaining uncovered sheets below are Tier 3 (lower priority) plus a few NEW items not yet picked up (school environment, Seal of Biliteracy detail, college/career breakdowns, and the redundant-low SPR mirror views).
 

--- a/man/fetch_spr_grad_pathways.Rd
+++ b/man/fetch_spr_grad_pathways.Rd
@@ -7,8 +7,8 @@
 fetch_spr_grad_pathways(end_year, level = "school")
 }
 \arguments{
-\item{end_year}{A school year. Only \code{2025} (SY2024-25) and later are
-supported.}
+\item{end_year}{A school year (2018-2022, 2024, or 2025). Year is the end of
+the academic year - e.g. the 2020-21 school year is \code{end_year} 2021.}
 
 \item{level}{One of \code{"school"} or \code{"district"}.}
 }
@@ -35,13 +35,24 @@ Pathways (columns, each a percentage on a 0-100 scale):
 }
 Percentages are returned numeric (suppressed cells become \code{NA}).
 
-\strong{Supported years:} only \code{end_year >= 2025} (the redesigned
-SY2024-25 SPR). Earlier databases do not include this sheet.
+\strong{Supported years:} 2018-2022, 2024, and 2025. The
+\code{GraduationPathways} sheet is present in those SPR databases (it is
+\strong{absent} from the SY2016-17 and SY2022-23 databases, which therefore
+error). Before the 2024-25 redesign the columns were named slightly
+differently (\code{ELA/Math}, \code{PARCCAssessment}/\code{StatewideAssessment},
+\code{SubstituteCompetency}, \code{PortfolioAppealsProcess},
+\code{AlternateReqIEP}); this function harmonizes them to the redesigned
+names and uppercases the subject label. The COVID-era executive-order waiver
+column present in the 2020 and 2021 sheets is not part of the four-pathway
+schema and is dropped.
 }
 \examples{
 \dontrun{
 # School-level graduation pathways
 gp <- fetch_spr_grad_pathways(2025)
+
+# The same pathway mix back to SY2017-18
+gp_2018 <- fetch_spr_grad_pathways(2018)
 
 # Statewide ELA pathway mix
 library(dplyr)

--- a/man/fetch_spr_home_language.Rd
+++ b/man/fetch_spr_home_language.Rd
@@ -7,8 +7,8 @@
 fetch_spr_home_language(end_year, level = "school")
 }
 \arguments{
-\item{end_year}{A school year. Only \code{2025} (SY2024-25) and later are
-supported.}
+\item{end_year}{A school year (2018-2025). Year is the end of the academic
+year - e.g. the 2020-21 school year is \code{end_year} 2021.}
 
 \item{level}{One of \code{"school"} or \code{"district"}.}
 }
@@ -26,13 +26,19 @@ catch-all). This breakdown is not available through \code{\link{fetch_enr}}.
 \code{percent_of_students} is returned numeric on a 0-100 scale (suppressed
 cells become \code{NA}).
 
-\strong{Supported years:} only \code{end_year >= 2025} (the redesigned
-SY2024-25 SPR). Earlier databases do not include this sheet.
+\strong{Supported years:} \code{end_year >= 2018}. The
+\code{EnrollmentByHomeLanguage} sheet is present back to SY2017-18 with an
+identical layout (the 2024-25 redesign only added a \code{SchoolYear} column,
+handled transparently). The SY2016-17 sheet omits the county/district/school
+name columns and is not supported.
 }
 \examples{
 \dontrun{
 # School-level home-language shares
 hl <- fetch_spr_home_language(2025)
+
+# The same breakdown back to SY2017-18
+hl_2018 <- fetch_spr_home_language(2018)
 
 # Statewide home-language distribution
 library(dplyr)

--- a/man/fetch_spr_naep.Rd
+++ b/man/fetch_spr_naep.Rd
@@ -7,8 +7,10 @@
 fetch_spr_naep(end_year)
 }
 \arguments{
-\item{end_year}{A school year. Only \code{2025} (SY2024-25) and later are
-supported.}
+\item{end_year}{A school year (2017-2025). Year is the end of the academic
+year - e.g. the 2024-25 school year is \code{end_year} 2025. Note this is
+the SPR publication year, not the NAEP administration year (see
+\code{test_year}).}
 }
 \value{
 Data frame with end_year (the SPR publication year), test_year (the
@@ -31,14 +33,23 @@ The \code{state_nation} column distinguishes \code{"New Jersey"} from
 given periodically, so multiple years appear). The four achievement-level
 columns are returned numeric on a 0-100 scale.
 
-\strong{Supported years:} only \code{end_year >= 2025} (the redesigned
-SY2024-25 SPR). Always reads the District/State database (the School database
-has no NAEP sheet).
+\strong{Supported years:} \code{end_year >= 2017}. Always reads the
+District/State database (the School database has no NAEP sheet). Before the
+2024-25 redesign the sheet used a leaner layout (\code{Year}, \code{Test},
+\code{Grade} and the four achievement levels) with no student-group
+breakdown; this function maps it to the redesigned shape: \code{Year ->
+test_year}, \code{Test -> subject}, the legacy \code{"State (NJ)"} label is
+normalized to \code{"New Jersey"}, and \code{student_group} is set to the
+constant \code{"All Students"} (the legacy sheet reports the all-students
+summary only; the per-subgroup breakdown was added in 2024-25).
 }
 \examples{
 \dontrun{
 # NAEP results as published in the 2024-25 SPR
 naep <- fetch_spr_naep(2025)
+
+# NAEP as published in an earlier SPR (all-students summary only)
+naep_2024 <- fetch_spr_naep(2024)
 
 # New Jersey vs. the nation, Grade 4 Math, most recent administration
 library(dplyr)

--- a/man/fetch_spr_staff_counts.Rd
+++ b/man/fetch_spr_staff_counts.Rd
@@ -7,8 +7,8 @@
 fetch_spr_staff_counts(end_year, level = "school")
 }
 \arguments{
-\item{end_year}{A school year. Only \code{2025} (SY2024-25) and later are
-supported.}
+\item{end_year}{A school year (2021-2025). Year is the end of the academic
+year - e.g. the 2020-21 school year is \code{end_year} 2021.}
 
 \item{level}{One of \code{"school"} or \code{"district"}.}
 }
@@ -28,11 +28,16 @@ The three count columns (\code{school_total_staff},
 returned numeric (thousands commas stripped; cells reading \dQuote{There is no
 data available for this school year.} set to \code{NA}).
 
-\strong{Supported years:} only \code{end_year >= 2025}.
+\strong{Supported years:} \code{end_year >= 2021}. The \code{StaffCounts}
+sheet first appears in the SY2020-21 SPR and has the same layout through the
+redesign. Earlier databases have no equivalent sheet.
 }
 \examples{
 \dontrun{
 staff <- fetch_spr_staff_counts(2025)
+
+# The same counts back to SY2020-21
+staff_2021 <- fetch_spr_staff_counts(2021)
 
 # Teacher counts by school
 library(dplyr)

--- a/man/fetch_spr_staff_education.Rd
+++ b/man/fetch_spr_staff_education.Rd
@@ -7,8 +7,8 @@
 fetch_spr_staff_education(end_year, level = "school")
 }
 \arguments{
-\item{end_year}{A school year. Only \code{2025} (SY2024-25) and later are
-supported.}
+\item{end_year}{A school year (2018-2025). Year is the end of the academic
+year - e.g. the 2020-21 school year is \code{end_year} 2021.}
 
 \item{level}{One of \code{"school"} or \code{"district"}.}
 }
@@ -27,11 +27,20 @@ Downloads the \code{TeachersAdminsEducation} sheet from the redesigned
 (suppressed/non-numeric cells, including the administrator note that
 administrators must hold a Master's or higher, set to \code{NA}).
 
-\strong{Supported years:} only \code{end_year >= 2025}.
+\strong{Supported years:} \code{end_year >= 2018}. Before the 2024-25
+redesign this sheet was named \code{TeachersAdminsLevelOfEducation}; the
+Bachelor's/Master's/Doctoral layout is identical from SY2017-18 on (this
+function selects the right sheet by year). The legacy sheet labels the
+administrator row \code{"Admin"}; it is normalized to \code{"Administrators"}
+for cross-year consistency. The SY2016-17 sheet uses a different long-format
+layout and is not supported.
 }
 \examples{
 \dontrun{
 edu <- fetch_spr_staff_education(2025)
+
+# The same degree distribution back to SY2017-18
+edu_2018 <- fetch_spr_staff_education(2018)
 
 # Share of teachers with a Master's degree, by school
 library(dplyr)

--- a/man/fetch_spr_staff_retention.Rd
+++ b/man/fetch_spr_staff_retention.Rd
@@ -7,8 +7,9 @@
 fetch_spr_staff_retention(end_year, level = "school")
 }
 \arguments{
-\item{end_year}{A school year. Only \code{2025} (SY2024-25) and later are
-supported.}
+\item{end_year}{A school year. \code{level = "district"} accepts 2018-2025;
+\code{level = "school"} accepts 2025 only. Year is the end of the academic
+year - e.g. the 2020-21 school year is \code{end_year} 2021.}
 
 \item{level}{One of \code{"school"} or \code{"district"}.}
 }
@@ -26,7 +27,13 @@ and for administrators, for the district and the state.
 \code{retention_pct_state} are returned numeric percentages (suppressed cells
 set to \code{NA}).
 
-\strong{Supported years:} only \code{end_year >= 2025}.
+\strong{Supported years:} \code{level = "district"} is supported for
+\code{end_year >= 2018}; \code{level = "school"} only for
+\code{end_year >= 2025}. The retention measure is reported at
+district/state granularity (no \code{SchoolCode}) in every SPR database
+through SY2023-24; the 2024-25 redesign was the first to add per-school
+retention rows. For earlier years, use \code{level = "district"}. (The
+SY2016-17 sheet additionally omits entity-name columns and is not supported.)
 }
 \examples{
 \dontrun{
@@ -38,5 +45,8 @@ fetch_spr_staff_retention(2025, level = "district") \%>\%
   filter(is_district, teachers_admins == "Teachers") \%>\%
   slice_min(retention_pct_district, n = 10) \%>\%
   select(district_name, retention_pct_district, retention_pct_state)
+
+# District/state retention back to SY2017-18
+ret_2018 <- fetch_spr_staff_retention(2018, level = "district")
 }
 }

--- a/tests/testthat/test-fetch-spr-grad-homelang-naep.R
+++ b/tests/testthat/test-fetch-spr-grad-homelang-naep.R
@@ -35,10 +35,16 @@ local_big_download_timeout <- function(seconds = 600, env = parent.frame()) {
 # Argument validation (no network)
 # ==============================================================================
 
-test_that("grad-pathways/home-language/NAEP error (no fabrication) for pre-2025", {
-  expect_error(fetch_spr_grad_pathways(2024), "end_year >= 2025")
-  expect_error(fetch_spr_home_language(2023), "end_year >= 2025")
-  expect_error(fetch_spr_naep(2020), "end_year >= 2025")
+# These sheets exist in earlier databases, so their fetchers were extended
+# backward. They error only below each sheet's real first available year.
+test_that("grad-pathways/home-language/NAEP error only below their real floor", {
+  # GraduationPathways: absent from SY2016-17 and SY2022-23 databases.
+  expect_error(fetch_spr_grad_pathways(2017), "end_year >= 2018")
+  expect_error(fetch_spr_grad_pathways(2023), "not available for end_year 2023")
+  # EnrollmentByHomeLanguage: SY2016-17 omits entity-name columns.
+  expect_error(fetch_spr_home_language(2017), "end_year >= 2018")
+  # NAEP is available back to SY2016-17.
+  expect_error(fetch_spr_naep(2016), "end_year >= 2017")
 })
 
 
@@ -168,4 +174,91 @@ test_that("fetch_spr_naep values match the raw NJ DOE file", {
   # Pinned from NAEP, 2024 administration, Grade 4 Mathematics, All Students:
   expect_equal(nj$proficient, 33)
   expect_equal(nation$below_basic, 24)
+})
+
+
+# ==============================================================================
+# Backfill to earlier years (pre-redesign databases)
+# ==============================================================================
+#
+# Values pinned against the NJ DOE SY2023-24 SPR workbooks:
+#   https://www.nj.gov/education/sprreports/download/DataFiles/2023-2024/
+# ==============================================================================
+
+test_that("fetch_spr_home_language backfills to SY2017-18 with matching values", {
+  skip_on_cran()
+  skip_if_offline()
+  local_big_download_timeout()
+
+  df <- fetch_spr_home_language(2024)
+  expect_true(all(spr_cols %in% names(df)))
+  expect_true(all(c("home_language", "percent_of_students") %in% names(df)))
+  expect_type(df$percent_of_students, "double")
+
+  ref <- df %>%
+    dplyr::filter(county_id == "01", district_id == "0010", school_id == "050")
+  # Pinned from EnrollmentByHomeLanguage, Emma C Attales, SY2023-24:
+  expect_equal(ref$percent_of_students[ref$home_language == "English"], 75.3)
+  expect_equal(ref$percent_of_students[ref$home_language == "Spanish"], 17.0)
+
+  # The sheet exists back to SY2017-18.
+  expect_gt(nrow(fetch_spr_home_language(2018, level = "district")), 0)
+})
+
+test_that("fetch_spr_naep backfills to SY2016-17 and maps the legacy layout", {
+  skip_on_cran()
+  skip_if_offline()
+  local_big_download_timeout()
+
+  df <- fetch_spr_naep(2024)
+  expect_true(all(c(
+    "end_year", "test_year", "state_nation", "subject", "grade",
+    "student_group", "below_basic", "basic", "proficient", "advanced"
+  ) %in% names(df)))
+  expect_false("county_id" %in% names(df))
+
+  # Legacy state label normalized; legacy sheet is all-students only.
+  expect_true(all(c("New Jersey", "Nation") %in% df$state_nation))
+  expect_false("State (NJ)" %in% df$state_nation)
+  expect_true(all(df$student_group == "All Students"))
+  expect_type(df$test_year, "integer")
+
+  g4math <- df %>%
+    dplyr::filter(test_year == 2024, subject == "Mathematics", grade == "4")
+  # Pinned from NAEP as published in the SY2023-24 SPR, 2024 administration:
+  expect_equal(g4math$proficient[g4math$state_nation == "New Jersey"], 33)
+  expect_equal(g4math$below_basic[g4math$state_nation == "Nation"], 24)
+
+  expect_gt(nrow(fetch_spr_naep(2017)), 0)
+})
+
+test_that("fetch_spr_grad_pathways backfills and harmonizes legacy columns", {
+  skip_on_cran()
+  skip_if_offline()
+  local_big_download_timeout()
+
+  df <- fetch_spr_grad_pathways(2024)
+  expect_true(all(spr_cols %in% names(df)))
+  expect_true(all(c(
+    "subject", "statewide_assessment", "substitute_competency_test",
+    "portfolio_appeals", "alternate_requirements_in_iep"
+  ) %in% names(df)))
+  # Subject label uppercased to match the redesigned sheet.
+  expect_true(all(c("ELA", "Math") %in% df$subject))
+  expect_false(any(c("ela", "math") %in% df$subject))
+
+  ref <- df %>%
+    dplyr::filter(county_id == "01", district_id == "0110", school_id == "010",
+                  subject == "ELA")
+  # Pinned from GraduationPathways, Atlantic City High School, ELA, SY2023-24:
+  expect_equal(ref$statewide_assessment, 62.1)
+  expect_equal(ref$substitute_competency_test, 4.4)
+  expect_equal(ref$portfolio_appeals, 20.0)
+  expect_equal(ref$alternate_requirements_in_iep, 13.0)
+
+  # 2018 maps the legacy PARCCAssessment column onto statewide_assessment.
+  gp18 <- fetch_spr_grad_pathways(2018, level = "district")
+  ac18 <- gp18 %>%
+    dplyr::filter(county_id == "01", district_id == "0110", subject == "ELA")
+  expect_equal(ac18$statewide_assessment, 97.3)
 })

--- a/tests/testthat/test-fetch-spr-staff.R
+++ b/tests/testthat/test-fetch-spr-staff.R
@@ -43,14 +43,26 @@ ref_emma <- function(df) {
 # Argument validation (no network)
 # ==============================================================================
 
-test_that("staff fetchers error (no fabrication) for pre-2025 years", {
+# These sheets are genuinely new in (or materially restructured for) the
+# 2024-25 redesign, so their fetchers stay gated at end_year >= 2025.
+test_that("redesign-only staff fetchers error (no fabrication) for pre-2025", {
   expect_error(fetch_spr_admin_experience(2024), "end_year >= 2025")
-  expect_error(fetch_spr_staff_counts(2024), "end_year >= 2025")
   expect_error(fetch_spr_staff_demo_subject(2024), "end_year >= 2025")
-  expect_error(fetch_spr_staff_education(2024), "end_year >= 2025")
-  expect_error(fetch_spr_staff_retention(2024), "end_year >= 2025")
   expect_error(fetch_spr_teacher_exp_subject(2024), "end_year >= 2025")
   expect_error(fetch_spr_educator_equity(2024), "end_year >= 2025")
+})
+
+# These sheets exist in earlier databases, so their fetchers were extended
+# backward. They error only below each sheet's real first year.
+test_that("backfilled staff fetchers error only below their real floor", {
+  # StaffCounts first appears in SY2020-21.
+  expect_error(fetch_spr_staff_counts(2020), "end_year >= 2021")
+  # TeachersAdminsLevelOfEducation: SY2016-17 uses a different layout.
+  expect_error(fetch_spr_staff_education(2017), "end_year >= 2018")
+  # Retention is district-granularity before 2025; school-level is 2025+.
+  expect_error(fetch_spr_staff_retention(2024), "level = 'district'")
+  expect_error(fetch_spr_staff_retention(2017, level = "district"),
+               "end_year >= 2018")
 })
 
 
@@ -238,4 +250,74 @@ test_that("fetch_spr_educator_equity returns the statewide summary (no CDS)", {
   expect_equal(nrow(oof), 1)
   # Pinned: 5.69% of students taught by an out-of-field teacher (core classes).
   expect_equal(oof$all_students, 0.0569)
+})
+
+
+# ==============================================================================
+# Backfill to earlier years (pre-redesign databases)
+# ==============================================================================
+#
+# Values pinned against the NJ DOE SY2023-24 SPR workbooks:
+#   https://www.nj.gov/education/sprreports/download/DataFiles/2023-2024/
+# Reference school: Absecon (county 01, district 0010), Emma C Attales
+# (school 050). Note retention is district-granularity before 2025.
+# ==============================================================================
+
+test_that("fetch_spr_staff_counts backfills to SY2020-21 with matching values", {
+  skip_on_cran()
+  skip_if_offline()
+  local_big_download_timeout()
+
+  df <- fetch_spr_staff_counts(2024)
+  expect_true(all(spr_cols %in% names(df)))
+  expect_true("staff_category" %in% names(df))
+
+  ref <- ref_emma(df)
+  # Pinned: Emma C Attales has 1 administrator and 37 teachers in SY2023-24.
+  expect_equal(ref$school_total_staff[ref$staff_category == "Administrators"], 1)
+  expect_equal(ref$school_total_staff[ref$staff_category == "Teachers"], 37)
+  # A role with no school-level value reads "N" -> NA.
+  expect_true(is.na(
+    ref$school_total_staff[ref$staff_category == "Child Study Team Members"]
+  ))
+
+  # The sheet first appears in SY2020-21.
+  expect_gt(nrow(fetch_spr_staff_counts(2021, level = "district")), 0)
+})
+
+test_that("fetch_spr_staff_education backfills via TeachersAdminsLevelOfEducation", {
+  skip_on_cran()
+  skip_if_offline()
+  local_big_download_timeout()
+
+  df <- fetch_spr_staff_education(2024)
+  expect_true(all(c("teachers_admins", "bachelors", "masters", "doctoral")
+                  %in% names(df)))
+  expect_type(df$masters, "double")
+
+  ref <- ref_emma(df)
+  # Pinned: Emma C Attales teachers 56.8% Bachelor's, 40.5% Master's,
+  # 2.7% Doctoral in SY2023-24.
+  expect_equal(ref$bachelors[ref$teachers_admins == "Teachers"], 56.8)
+  expect_equal(ref$masters[ref$teachers_admins == "Teachers"], 40.5)
+  expect_equal(ref$doctoral[ref$teachers_admins == "Teachers"], 2.7)
+  # The legacy "Admin" label is normalized to "Administrators".
+  expect_true("Administrators" %in% df$teachers_admins)
+  expect_false("Admin" %in% df$teachers_admins)
+})
+
+test_that("fetch_spr_staff_retention backfills at district level", {
+  skip_on_cran()
+  skip_if_offline()
+  local_big_download_timeout()
+
+  df <- fetch_spr_staff_retention(2024, level = "district")
+  expect_true(all(c("teachers_admins", "retention_pct_district",
+                    "retention_pct_state") %in% names(df)))
+  expect_type(df$retention_pct_district, "double")
+
+  ref <- dplyr::filter(df, county_id == "01", district_id == "0010")
+  # Pinned: Absecon teacher retention 93.5% (district), 89.5% (state) in SY2023-24.
+  expect_equal(ref$retention_pct_district[ref$teachers_admins == "Teachers"], 93.5)
+  expect_equal(ref$retention_pct_state[ref$teachers_admins == "Teachers"], 89.5)
 })


### PR DESCRIPTION
## Summary

Six of the redesigned SY2024-25 SPR fetchers added in #251/#252 were gated at `end_year >= 2025` as a conservative default ("error rather than guess a mapping"), not because earlier data was missing. An audit of the 2017-2024 SPR workbooks (both `Database_SchoolDetail.xlsx` and `Database_DistrictStateDetail.xlsx`) found the source sheets exist in earlier databases. Each fetcher now reaches its real first year and errors only below that floor.

| Fetcher | New range | How |
|---|---|---|
| `fetch_spr_home_language()` | **2018-2025** | Same sheet, identical columns minus the 2025-only `SchoolYear`. SY2016-17 omits entity-name columns. |
| `fetch_spr_staff_counts()` | **2021-2025** | `StaffCounts` first appears SY2020-21; identical columns. |
| `fetch_spr_staff_education()` | **2018-2025** | Reads the legacy `TeachersAdminsLevelOfEducation` sheet; `"Admin"` label normalized to `"Administrators"`. SY2016-17 is long-format. |
| `fetch_spr_staff_retention()` | **2018-2025 (district)** | Measure is district-granularity (no `SchoolCode`) before 2025; school-level rows are 2025+, so `level="school"` stays gated pre-2025 with a message pointing to `level="district"`. |
| `fetch_spr_naep()` | **2017-2025** | Legacy `Year`/`Test`/`Grade` layout mapped to the redesigned shape; `"State (NJ)"` -> `"New Jersey"`; legacy is all-students only, so `student_group = "All Students"`. |
| `fetch_spr_grad_pathways()` | **2018-2022, 2024-2025** | Legacy column names harmonized, subject label uppercased; COVID waiver column dropped. **Absent in SY2016-17 and SY2022-23** (those years error). |

## Stays gated at 2025+ (documented)

- ESSA long-term-goal target suite (`fetch_spr_essa_targets` x6), `fetch_spr_accountability_summative`, `fetch_spr_tsi`, `fetch_spr_essa_status_counts`, `fetch_spr_staff_demo_subject`, `fetch_spr_teacher_exp_subject` — their sheets are absent from every 2017-2024 workbook.
- `fetch_spr_admin_experience` — exists earlier but across four incompatible layouts (granularity + column-name churn).
- `fetch_spr_educator_equity` — exists earlier but on a different scale (legacy percentages vs 2025 proportions, a 100x shift) and without the `Classes Included` dimension. Forcing it into the 2025 shape would mis-scale or fabricate.

## Verification

Every backfilled fetcher was run against the real NJ DOE workbooks for each new year. Tests add legacy-year assertions with values pinned to the raw files (e.g. 2023-24 Emma C Attales home-language English 75.3%; Atlantic City HS ELA statewide-assessment pathway 62.1%; 2024 NAEP Grade 4 Math NJ proficient 33%). The two changed test files pass fully (live tests run locally against the workbooks). No data is fabricated; every value traces to a downloaded NJ DOE sheet.