### PR TITLE
Release 0.9.7

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: A Simple Interface for Accessing NJ DOE School Data in R and Python
 Description: R functions (with Python bindings) to import NJ school data,
     including assessment, enrollment, and accountability data from the
     New Jersey Department of Education.
-Version: 0.9.6
+Version: 0.9.7
 Authors@R: person("Andrew", "Martin", role = c("aut","cre"),
     email = "almartin@gmail.com")
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,48 @@
+# njschooldata 0.9.7
+
+## New features
+
+* New School Performance Report (SPR) fetchers for the redesigned 2024-25
+  databases:
+  - ESSA accountability: `fetch_spr_essa_targets()` (six long-term-goal
+    indicators), `fetch_spr_accountability_summative()`, `fetch_spr_tsi()`,
+    `fetch_spr_essa_status_counts()`, and a fixed district-level
+    `fetch_essa_status()`.
+  - Graduation, language, and assessment: `fetch_spr_grad_pathways()`,
+    `fetch_spr_home_language()`, `fetch_spr_naep()`.
+  - Staff: `fetch_spr_admin_experience()`, `fetch_spr_staff_counts()`,
+    `fetch_spr_staff_demo_subject()`, `fetch_spr_staff_education()`,
+    `fetch_spr_staff_retention()`, `fetch_spr_teacher_exp_subject()`,
+    `fetch_spr_educator_equity()`.
+
+* Historical coverage: the 2024-25 SPR fetchers were extended backward to the
+  earliest year each source sheet exists with a structure that maps to the
+  redesigned shape without fabrication (e.g. `fetch_spr_home_language()` and
+  `fetch_spr_staff_education()` to 2018, `fetch_spr_naep()` to 2017,
+  `fetch_spr_grad_pathways()` across 2018-2022 and 2024). Years where the
+  underlying sheet is absent or reports a different measure error with an
+  explanatory message rather than guessing a mapping.
+
+* `fetch_sgp()` (median Student Growth Percentiles) now supports pre-2025 years:
+  `type = "by_grade"` and `type = "trends"` back to 2018, and
+  `type = "by_performance_level"` to 2023. SY2019-20 through SY2021-22 remain
+  unavailable (NJ produced no SGP during the COVID assessment pause), and the
+  pre-2020 by-performance-level sheet (a growth-band percentage distribution,
+  not a median SGP) stays gated. Pre-2025 `trends` rows preserve the legacy
+  `MetTarget` flag in new `ela_met_target` / `math_met_target` columns.
+
+## Performance
+
+* SPR Excel workbooks are now cached on disk (per year + level), so a workbook
+  is downloaded from NJ DOE at most once and reused across sheet reads and
+  across sessions -- reading a second sheet from the 2024-25 District file drops
+  from ~12s to ~0.1s. New helpers: `njsd_workbook_cache_dir()`,
+  `njsd_workbook_cache_info()`, `njsd_workbook_cache_clear()`. Relocate the
+  cache with `options(njschooldata.cache_dir =)` or disable it with
+  `options(njschooldata.workbook_cache = FALSE)`. Downloads are validated as
+  real `.xlsx` files (ZIP signature) before caching, so an HTTP error or
+  bot-protection page is never cached or parsed as data.
+
 # njschooldata 0.9.6
 
 ## Infrastructure


### PR DESCRIPTION
Bumps `DESCRIPTION` to **0.9.7** and adds the `NEWS.md` entry covering everything merged since 0.9.6 (which only documented the geocoding migration):

- **New SPR fetchers** for the redesigned 2024-25 databases — ESSA accountability/targets/TSI/status, graduation pathways, home language, NAEP, and the staff suite (#250–#252).
- **Historical backfill** of those fetchers to the earliest non-fabricated year (#254).
- **`fetch_sgp()` pre-2025 backfill** — `by_grade`/`trends` to 2018, `by_performance_level` to 2023, with the COVID gap and the pre-2020 measure change documented (#255, #256).
- **On-disk SPR workbook cache** — download each workbook once, reuse across sheets/sessions (~12s → ~0.1s), with validation (#257).

Docs-only + version metadata; no functional code change. CI (R-CMD-check / Python / pkgdown) re-runs on merge and the pkgdown site picks up the new version.