### PR TITLE
Fix pkgdown deploy: register tges-analyst-guide vignette in articles index

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Version: 0.9.11
 Authors@R: person("Andrew", "Martin", role = c("aut","cre"),
     email = "almartin@gmail.com")
 License: MIT + file LICENSE
-URL: https://github.com/almartin82/njschooldata
+URL: https://github.com/almartin82/njschooldata, https://almartin82.github.io/njschooldata/
 BugReports: https://github.com/almartin82/njschooldata/issues
 Depends:
     R (>= 4.1.0)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -235,6 +235,7 @@ articles:
       - newark-school-spending
       - newark-fiscal-brief
       - newark-efficiency-frontier
+      - tges-analyst-guide
   - title: School Performance Reports
     navbar: ~
     contents:


### PR DESCRIPTION
## Problem

The `pkgdown` deploy workflow has been failing since PR #266 ("Add 'Head First Analyst's Guide to NJ TGES' vignette"). `R-CMD-check` and `Python Tests` pass; only the deploy fails.

Fatal error from the build:

```
✖ Articles metadata not ok.
  In _pkgdown.yml, 1 vignette missing from index: "tges-analyst-guide".
Error in `build_articles_index()`: Execution halted
```

`_pkgdown.yml` uses an **explicit** `articles:` index. PR #266 added `vignettes/tges-analyst-guide.Rmd` but never registered it there, so pkgdown aborts.

## Fix

- Add `tges-analyst-guide` to the `articles:` index under **School Finance** (TGES is fiscal data).
- Add the pkgdown site URL to `DESCRIPTION` `URL:` to clear the non-fatal `URLs not ok` warning.

## Verification

`pkgdown::check_pkgdown()` now returns `✔ No problems found.`