### PR TITLE
Report tests aggregated and school counts on PARCC aggregates

### DIFF
--- a/R/agg_calcs.R
+++ b/R/agg_calcs.R
@@ -122,7 +122,21 @@ parcc_perf_level_counts <- function(df) {
 #'
 #' @param df grouped df of PARCC data
 #'
-#' @return df with aggregate stats for whatever grouping was provided
+#' @return df with aggregate stats for whatever grouping was provided. In
+#'   addition to the rolled-up counts and recomputed percentages, the output
+#'   records provenance of each aggregate row:
+#'   \describe{
+#'     \item{districts}{collapsed list of the district names rolled up}
+#'     \item{schools}{collapsed list of the school names rolled up}
+#'     \item{tests}{collapsed list of the test(s) (\code{test_name}, e.g.
+#'       "math"/"ela"/"science") rolled into the row, so callers can see which
+#'       assessment(s) an aggregate combines (issue #98)}
+#'     \item{n_schools}{number of distinct schools contributing to the row.
+#'       Uses \code{n_distinct(school_name)} because the grouped input holds one
+#'       row per (school, grade/course) -- e.g. a 3-8 school appears as six rows
+#'       -- so \code{n()} would overcount. (issue #70)}
+#'     \item{n_charter_rows}{number of input rows flagged \code{is_charter}}
+#'   }
 #' @export
 parcc_aggregate_calcs <- function(df) {
   df %>%
@@ -142,6 +156,15 @@ parcc_aggregate_calcs <- function(df) {
       num_l5 = sum(num_l5, na.rm = TRUE),
       districts = collapse_agg_names(district_name),
       schools = collapse_agg_names(school_name),
+      # issue #98: record which test(s) were rolled into this aggregate row.
+      # test_name holds the assessment subject ("math"/"ela"/"science"). For a
+      # single-subject roll-up this collapses to one name; for any future
+      # caller that groups across subjects it lists each with its count.
+      tests = collapse_agg_names(test_name),
+      # issue #70: count distinct schools contributing to the row, mirroring the
+      # n_charter_rows pattern. n_distinct (not n) because the grouped input has
+      # one row per (school, grade/course), so a school spans multiple rows.
+      n_schools = dplyr::n_distinct(school_name),
       n_charter_rows = sum(is_charter, na.rm = TRUE)
     ) %>%
     dplyr::mutate(
@@ -208,6 +231,19 @@ calculate_agg_parcc_prof <- function(end_year, subj, gradespan = "3-11") {
   all_grades <- parcc_perf_level_counts(all_grades)
 
   # group, aggregate, return
+  #
+  # NOTE (#98 group-by decision): `grade` is intentionally NOT a grouping key, so
+  # the per-grade/per-course files (e.g. math grades 03-08 + ALG1/GEO/ALG2) roll
+  # up into a single "3-11" row. `test_name` IS kept as a grouping key, but in
+  # this package test_name is the assessment *subject* ("math"/"ela"/"science")
+  # -- set once via `parcc_file$test_name <- subj` in process_parcc() -- not the
+  # grade/course. Because every file fetched here shares one subject, test_name
+  # is constant and keeping it in group_by does NOT fragment the gradespan
+  # aggregate (verified against 2023 math 3-11: one state total_population row).
+  # Keeping it preserves the test_name column in the output; the new
+  # `tests` column added in parcc_aggregate_calcs() then reports the test(s)
+  # combined per #98 and stays meaningful for any caller that groups across
+  # subjects.
   all_grades %>%
     dplyr::filter(!is.na(county_id)) %>%
     dplyr::group_by(

--- a/R/globals.R
+++ b/R/globals.R
@@ -215,7 +215,7 @@ utils::globalVariables(c(
   "school_year", "two_or_more_races",
 
   # ========== PARCC/Assessment Aggregates ==========
-  "districts", "schools", "n_charter_rows",
+  "districts", "schools", "tests", "n_charter_rows",
   "gradespan",
 
   # ========== Report Card Columns ==========

--- a/R/process_assessment.R
+++ b/R/process_assessment.R
@@ -93,7 +93,7 @@ parcc_column_order <- function(df) {
       scale_score_mean,
       pct_l1, pct_l2, pct_l3, pct_l4, pct_l5, proficient_above,
       num_l1, num_l2, num_l3, num_l4, num_l5,
-      dplyr::one_of("n_charter_rows", "n_schools", "districts", "schools"),
+      dplyr::one_of("n_charter_rows", "n_schools", "tests", "districts", "schools"),
       is_state, is_dfg,
       is_district, is_school, is_charter,
       is_charter_sector,

--- a/man/parcc_aggregate_calcs.Rd
+++ b/man/parcc_aggregate_calcs.Rd
@@ -10,7 +10,21 @@ parcc_aggregate_calcs(df)
 \item{df}{grouped df of PARCC data}
 }
 \value{
-df with aggregate stats for whatever grouping was provided
+df with aggregate stats for whatever grouping was provided. In
+  addition to the rolled-up counts and recomputed percentages, the output
+  records provenance of each aggregate row:
+  \describe{
+    \item{districts}{collapsed list of the district names rolled up}
+    \item{schools}{collapsed list of the school names rolled up}
+    \item{tests}{collapsed list of the test(s) (\code{test_name}, e.g.
+      "math"/"ela"/"science") rolled into the row, so callers can see which
+      assessment(s) an aggregate combines (issue #98)}
+    \item{n_schools}{number of distinct schools contributing to the row.
+      Uses \code{n_distinct(school_name)} because the grouped input holds one
+      row per (school, grade/course) -- e.g. a 3-8 school appears as six rows
+      -- so \code{n()} would overcount. (issue #70)}
+    \item{n_charter_rows}{number of input rows flagged \code{is_charter}}
+  }
 }
 \description{
 Aggregate multiple PARCC rows and produce summary statistics

--- a/tests/testthat/test_parcc_agg_provenance.R
+++ b/tests/testthat/test_parcc_agg_provenance.R
@@ -1,0 +1,200 @@
+# =============================================================================
+# Issue #98 + #70: PARCC aggregate provenance columns
+#
+#   #98 -> parcc_aggregate_calcs() should report which test(s) were combined,
+#          via `tests = collapse_agg_names(test_name)`.
+#   #70 -> parcc_aggregate_calcs() should report how many schools were combined,
+#          mirroring n_charter_rows, via `n_schools = n_distinct(school_name)`.
+#
+# The data frames below are TEST-ONLY logic fixtures. Every number is chosen by
+# hand purely to exercise the aggregation MATH and the new provenance columns.
+# They are NOT real NJ DOE figures, are never written to data/ or
+# inst/extdata/, and must not be presented as actual assessment results.
+# =============================================================================
+
+test_that("parcc_aggregate_calcs reports tests and n_schools and rolls up counts (#98, #70)", {
+  # TEST-ONLY fixture (not real NJ data): a single district with two schools.
+  # School A is a 3-8 school -> 2 math grade rows (03, 04).
+  # School B is a high school -> 1 math course row (ALG1).
+  # All rows share test_name = "math". This mirrors the real grouped input that
+  # calculate_agg_parcc_prof() feeds in: one row per (school, grade/course),
+  # with grade NOT a grouping key so grades roll up into one span row.
+  test_df <- tibble::tibble(
+    district_name = rep("TEST DISTRICT", 3),
+    school_name = c("School A", "School A", "School B"),
+    test_name = rep("math", 3),
+    grade = c("03", "04", "ALG1"),
+    is_charter = c(FALSE, FALSE, FALSE),
+    number_enrolled = c(100, 110, 90),
+    number_not_tested = c(5, 4, 6),
+    number_of_valid_scale_scores = c(100, 100, 100),
+    scale_score_mean = c(740, 750, 760),
+    # Performance-level percentages sum to 100 within each row.
+    pct_l1 = c(10, 10, 10),
+    pct_l2 = c(20, 20, 20),
+    pct_l3 = c(30, 30, 30),
+    pct_l4 = c(25, 25, 25),
+    pct_l5 = c(15, 15, 15)
+  ) %>%
+    parcc_perf_level_counts()
+
+  result <- test_df %>%
+    dplyr::group_by(district_name) %>%
+    parcc_aggregate_calcs() %>%
+    dplyr::ungroup()
+
+  # One aggregate row for the single district group.
+  expect_equal(nrow(result), 1)
+
+  # ---- #98: tests column ----
+  # All three input rows are test_name "math", so it collapses to a single name.
+  expect_true("tests" %in% names(result))
+  expect_equal(result$tests, "math")
+
+  # ---- #70: n_schools column ----
+  # Two distinct schools (A, B) across three rows. n_distinct, not n(): if this
+  # used n() it would return 3 (one per grade/course row), overcounting.
+  expect_true("n_schools" %in% names(result))
+  expect_equal(result$n_schools, 2L)
+
+  # Sanity check that the existing schools-string collapsing still works:
+  # School A appears in 2 rows, School B in 1.
+  expect_equal(result$schools, "School A (2), School B (1)")
+
+  # ---- enrollment / not-tested / valid-score sums roll up correctly ----
+  expect_equal(result$number_enrolled, 100 + 110 + 90)
+  expect_equal(result$number_not_tested, 5 + 4 + 6)
+  expect_equal(result$number_of_valid_scale_scores, 100 + 100 + 100)
+
+  # ---- performance-level counts roll up correctly ----
+  # Each row has 100 valid scores, so num_lX = pct_lX per row; summed over 3 rows.
+  expect_equal(result$num_l1, 3 * 10)
+  expect_equal(result$num_l2, 3 * 20)
+  expect_equal(result$num_l3, 3 * 30)
+  expect_equal(result$num_l4, 3 * 25)
+  expect_equal(result$num_l5, 3 * 15)
+
+  # ---- recomputed percentages off the rolled-up counts ----
+  # 300 valid scores total; e.g. num_l1 = 30 -> pct_l1 = 10.0
+  expect_equal(result$pct_l1, 10.0)
+  expect_equal(result$pct_l4, 25.0)
+  expect_equal(result$pct_l5, 15.0)
+  # proficient_above = (num_l4 + num_l5) / valid * 100 = (75 + 45) / 300 * 100
+  expect_equal(result$proficient_above, 40.0)
+
+  # ---- enrollment-weighted scale score mean ----
+  # weighted by valid scores (equal weights here): mean(740, 750, 760) = 750
+  expect_equal(result$scale_score_mean, 750)
+})
+
+
+test_that("parcc_aggregate_calcs tests column lists multiple tests with counts when subjects mix (#98)", {
+  # TEST-ONLY fixture (not real NJ data): a single school with one math row and
+  # two ela rows, to confirm `tests` enumerates each distinct test_name with its
+  # count when an aggregate genuinely spans more than one assessment.
+  test_df <- tibble::tibble(
+    district_name = rep("TEST DISTRICT", 3),
+    school_name = rep("School A", 3),
+    test_name = c("math", "ela", "ela"),
+    grade = c("03", "03", "04"),
+    is_charter = rep(FALSE, 3),
+    number_enrolled = rep(100, 3),
+    number_not_tested = rep(0, 3),
+    number_of_valid_scale_scores = rep(100, 3),
+    scale_score_mean = rep(750, 3),
+    pct_l1 = rep(20, 3),
+    pct_l2 = rep(20, 3),
+    pct_l3 = rep(20, 3),
+    pct_l4 = rep(20, 3),
+    pct_l5 = rep(20, 3)
+  ) %>%
+    parcc_perf_level_counts()
+
+  result <- test_df %>%
+    dplyr::group_by(district_name) %>%
+    parcc_aggregate_calcs() %>%
+    dplyr::ungroup()
+
+  # ela appears in 2 rows, math in 1; collapse_agg_names sorts by frequency desc.
+  expect_equal(result$tests, "ela (2), math (1)")
+  # Single school across all three rows.
+  expect_equal(result$n_schools, 1L)
+})
+
+
+test_that("parcc_aggregate_calcs n_charter_rows is unchanged by new columns (#70 mirrors #69)", {
+  # TEST-ONLY fixture (not real NJ data): mix of charter and non-charter rows to
+  # confirm n_charter_rows (the #69 pattern n_schools is modeled on) still counts
+  # flagged input rows, independent of the new n_schools distinct-school count.
+  test_df <- tibble::tibble(
+    district_name = rep("TEST DISTRICT", 4),
+    school_name = c("Charter A", "Charter A", "Charter B", "District School"),
+    test_name = rep("math", 4),
+    grade = c("03", "04", "03", "03"),
+    is_charter = c(TRUE, TRUE, TRUE, FALSE),
+    number_enrolled = rep(100, 4),
+    number_not_tested = rep(0, 4),
+    number_of_valid_scale_scores = rep(100, 4),
+    scale_score_mean = rep(750, 4),
+    pct_l1 = rep(20, 4),
+    pct_l2 = rep(20, 4),
+    pct_l3 = rep(20, 4),
+    pct_l4 = rep(20, 4),
+    pct_l5 = rep(20, 4)
+  ) %>%
+    parcc_perf_level_counts()
+
+  result <- test_df %>%
+    dplyr::group_by(district_name) %>%
+    parcc_aggregate_calcs() %>%
+    dplyr::ungroup()
+
+  # 3 charter-flagged input rows.
+  expect_equal(result$n_charter_rows, 3L)
+  # 3 distinct schools (Charter A counted once despite 2 rows).
+  expect_equal(result$n_schools, 3L)
+})
+
+
+test_that("calculate_agg_parcc_prof carries tests and n_schools through to output (#98, #70)", {
+  # Integration test against live NJ DOE data; skips offline or if unavailable.
+  skip_if_offline()
+
+  agg <- tryCatch(
+    calculate_agg_parcc_prof(end_year = 2023, subj = "math", gradespan = "3-11"),
+    error = function(e) NULL
+  )
+  skip_if(is.null(agg), "PARCC data URL not accessible")
+
+  expect_true(all(c("tests", "n_schools") %in% names(agg)))
+
+  # gradespan label applied after aggregation; grades genuinely rolled up.
+  expect_true(all(agg$grade == "3-11"))
+  # single subject in, so tests collapses to "math" on every row.
+  expect_true(all(agg$tests == "math"))
+
+  # n_schools is a non-negative count.
+  expect_true(all(agg$n_schools >= 0))
+
+  # A school-level row aggregates only that school -> exactly one distinct
+  # school name in its input rows.
+  school_rows <- agg %>% dplyr::filter(is_school)
+  if (nrow(school_rows) > 0) {
+    expect_true(all(school_rows$n_schools == 1))
+  }
+
+  # NJ DOE district/state rows are themselves pre-aggregated summary rows that
+  # carry no school name (school_name is NA), so n_distinct(school_name) is 1
+  # for those groups. n_schools counts distinct school NAMES among the grouped
+  # input rows -- not the universe of schools in NJ -- so district- and
+  # state-level aggregates correctly report 1.
+  district_rows <- agg %>% dplyr::filter(is_district)
+  if (nrow(district_rows) > 0) {
+    expect_true(all(district_rows$n_schools == 1))
+  }
+  state_total <- agg %>%
+    dplyr::filter(is_state, subgroup == "total_population")
+  if (nrow(state_total) > 0) {
+    expect_equal(unique(state_total$n_schools), 1L)
+  }
+})


### PR DESCRIPTION
Closes #98
Closes #70

## What changed

`parcc_aggregate_calcs()` (R/agg_calcs.R) now emits two provenance columns on every aggregate row, alongside the existing `districts`, `schools`, and `n_charter_rows`:

- **`tests = collapse_agg_names(test_name)`** (#98) — records which test(s) were rolled into the aggregate row. For a single-subject roll-up this collapses to one name (e.g. `"math"`); for any caller that groups across subjects it enumerates each with its count (e.g. `"ela (2), math (1)"`).
- **`n_schools = dplyr::n_distinct(school_name)`** (#70) — counts how many distinct schools contributed to the row, mirroring the `n_charter_rows` pattern added in #69.

Also: added `tests` to `parcc_column_order()` (R/process_assessment.R) and to the global variable list (R/globals.R), regenerated the `@return` roxygen for `parcc_aggregate_calcs`, and added tests.

## #98 group-by decision (with reasoning)

The issue asks the aggregate to "report what test(s) they are aggregating." There was a concern that `test_name` in `calculate_agg_parcc_prof()`'s `group_by` would fragment the `3-11` math aggregate (since math 3-11 pulls grades 03-08 plus ALG1/GEO/ALG2).

I verified against live NJ DOE data (2023) before deciding:

- In this package, `test_name` is the assessment **subject** — set once via `parcc_file$test_name <- subj` in `process_parcc()`. It is `"math"` / `"ela"` / `"science"`, **not** the grade/course. The grade/course code (`"03"`, ..., `"ALG1"`, `"GEO"`, `"ALG2"`) lives in the separate `grade` column.
- `grade` is **not** a grouping key in `calculate_agg_parcc_prof()`, so the per-grade/course files already roll up into a single span row. Running `calculate_agg_parcc_prof(2023, "math", "3-11")` produces exactly **one** state `total_population` row — the across-grade aggregation already works.
- Because every file fetched in one call shares a single subject, `test_name` is constant, so keeping it in the `group_by` does **not** fragment the aggregate. Removing it would instead drop the `test_name` column from the summarized output (it would no longer be a grouping column), a regression.

Decision: **keep `test_name` in the `group_by` (option a)** and add the `tests` column. This satisfies #98's "report the test(s)" without changing the (already-correct) aggregation, and `tests` stays load-bearing for callers like `charter_sector_parcc_aggs()` that can combine rows across subjects. A code comment documents this in `calculate_agg_parcc_prof()`.

## #70 n_distinct vs n() decision

The grouped input to `parcc_aggregate_calcs()` holds **one row per (school, grade/course)** — e.g. a 3-8 school appears as up to six rows, and a district-level group spans many such rows. Verified empirically: one real district had 7 rows (grades 03-08 + ALG1), and a single school had 2 grade rows. So `n()` would overcount; **`n_distinct(school_name)`** is correct. Documented in a code comment and the roxygen.

Note on level semantics (honest behavior): NJ DOE district/state PARCC rows are themselves pre-aggregated summary rows that carry no school name (`school_name` is `NA`), so `n_schools` is 1 for those groups. `n_schools` truthfully counts distinct school names among the rows being combined — it is most informative when the input is genuinely school-level rows (the deterministic tests cover that case).

## Tests

New `tests/testthat/test_parcc_agg_provenance.R`:

- Three **deterministic** unit tests on small, clearly-commented test-only fixtures (NOT bundled NJ data) verifying: `tests` collapses correctly for single- and multi-subject groups, `n_schools` uses distinct counting (2 schools across 3 grade rows -> 2, not 3), `n_charter_rows` is unaffected, and that enrollment / not-tested / valid-score / level-count sums and recomputed percentages roll up correctly.
- One **integration** test of `calculate_agg_parcc_prof()` guarded by `skip_if_offline()` + `skip_if(is.null(...))`.

Local result: `devtools::test(filter = "parcc_agg_provenance")` -> **PASS 30, FAIL 0, SKIP 0** (integration test ran live). No new regressions in the broader suite (the 3 pre-existing failures in `test_issue_reproductions.R` are present on `master` and are unrelated to this change).