### PR TITLE
Fix overlapping layout fields for legacy NJ assessment parser (#47, #53)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,20 @@
   `FALSE` preserves the existing per-subgroup behavior. Pairs naturally with
   the new Group/Grade detail fetchers for disproportionality analysis.
 
+## Bug fixes
+
+* `common_fwf_req()` (the workhorse fixed-width parser behind `fetch_njask()`,
+  `fetch_hspa()`, `fetch_gepa()`, and `fetch_old_nj_assess()`) no longer
+  fails with `"Overlapping specification not supported"` on the legacy
+  NJASK/HSPA/GEPA layouts. Every layout encodes the composite county-
+  district-school identifier (positions 1-9) alongside its decomposed parts
+  (`County_Code` 1-2, `District_Code` 3-6, `School_Code` 7-9), and several
+  also carry a `RECORD_KEY` (1-9). The parser now detects these redundant
+  composites, drops them before calling `readr::fwf_positions()`, and
+  reconstructs them post-parse by concatenating the component parts. The
+  on-disk layout metadata is untouched, so it remains a faithful description
+  of the upstream NJ DOE file format. (#47, #53)
+
 ## Improvements
 
 * `tidy_nj_assess()` (used by `fetch_old_nj_assess(tidy = TRUE)` for

--- a/R/fetch_nj_assess.R
+++ b/R/fetch_nj_assess.R
@@ -381,9 +381,138 @@ nj_coltype_parser <- function(datatypes) {
 }
 
 
+#' Detect redundant composite fields in a fixed-width layout
+#'
+#' A field is "redundant" if its `[field_start_position, field_end_position]`
+#' interval is the exact, disjoint union of two or more OTHER fields with
+#' strictly narrower intervals. The canonical case in the NJASK/HSPA/GEPA
+#' layouts is the composite county-district-school identifier (positions
+#' 1-9), which decomposes into `County_Code` (1-2), `District_Code` (3-6),
+#' and `School_Code` (7-9). Several layouts also carry a `RECORD_KEY`
+#' (positions 1-9) that overlaps the same range.
+#'
+#' `readr::fwf_positions()` rejects layouts with any overlap, so these
+#' composite rows must be dropped before parsing and then reconstructed
+#' from their components afterward.
+#'
+#' @param layout A data frame with `field_start_position`,
+#'   `field_end_position`, and `final_name` columns.
+#' @return A logical vector of length `nrow(layout)`; `TRUE` marks rows to
+#'   drop before calling `readr::fwf_positions()`. Rows with the same
+#'   interval as another redundant composite (e.g. both `RECORD_KEY` and
+#'   the composite identifier both covering 1-9) are all flagged.
+#' @keywords internal
+#' @noRd
+find_redundant_overlaps <- function(layout) {
+  n <- nrow(layout)
+  redundant <- logical(n)
+  if (n < 2) return(redundant)
+
+  starts <- layout$field_start_position
+  ends   <- layout$field_end_position
+  widths <- ends - starts + 1L
+
+  for (i in seq_len(n)) {
+    width_i <- widths[i]
+    # Candidate component rows: strictly inside row i's interval AND
+    # strictly narrower (so a composite cannot "decompose" itself, and
+    # two identical-interval composites do not absorb each other).
+    candidate <- which(
+      starts >= starts[i] & ends <= ends[i] & widths < width_i
+    )
+    if (length(candidate) < 2L) next
+
+    # Sort candidates by start, then check that they (a) are pairwise
+    # disjoint and (b) their union exactly covers row i.
+    ord <- order(starts[candidate])
+    cs <- starts[candidate][ord]
+    ce <- ends[candidate][ord]
+
+    # First candidate must start where row i starts; last must end where it
+    # ends; consecutive candidates must abut without gap or overlap.
+    if (cs[1] != starts[i]) next
+    if (ce[length(ce)] != ends[i]) next
+    if (length(cs) > 1L && !all(ce[-length(ce)] + 1L == cs[-1])) next
+
+    redundant[i] <- TRUE
+  }
+
+  redundant
+}
+
+
+#' Reconstruct a composite fixed-width field from its component parts
+#'
+#' Used after `readr::read_fwf()` to rebuild a composite identifier
+#' (e.g. the legacy assessment composite county-district-school code or
+#' `RECORD_KEY`) that was dropped via `find_redundant_overlaps()`.
+#' Components are pasted together in positional order with zero-width
+#' concatenation; if any component is `NA` for a given row, the composite
+#' is `NA` for that row.
+#'
+#' The reconstructed column is inserted into `df` at the positional index
+#' implied by the row's original placement in the full layout, so that
+#' downstream code addressing `df` by column position (e.g.
+#' `process_nj_assess()`) continues to align with the layout.
+#'
+#' @param df Data frame produced by `readr::read_fwf()` against
+#'   `parse_layout`.
+#' @param composite_row A one-row data frame slice from the original layout
+#'   describing the composite (`field_start_position`,
+#'   `field_end_position`, `final_name`, and a numeric `..orig_index`
+#'   column giving its row number in the full layout).
+#' @param parse_layout The deduplicated layout that was passed to
+#'   `readr::read_fwf()`.
+#' @return `df` with the composite column added back.
+#' @keywords internal
+#' @noRd
+reconstruct_composite_field <- function(df, composite_row, parse_layout) {
+  composite_name  <- composite_row$final_name[[1]]
+  composite_start <- composite_row$field_start_position[[1]]
+  composite_end   <- composite_row$field_end_position[[1]]
+
+  component_idx <- which(
+    parse_layout$field_start_position >= composite_start &
+      parse_layout$field_end_position <= composite_end
+  )
+  if (length(component_idx) == 0L) {
+    stop(
+      "Cannot reconstruct composite field '", composite_name,
+      "': no component fields found inside [", composite_start, ", ",
+      composite_end, "]."
+    )
+  }
+
+  # Order component rows positionally so concatenation matches the
+  # composite's byte order.
+  component_idx <- component_idx[
+    order(parse_layout$field_start_position[component_idx])
+  ]
+  component_names <- parse_layout$final_name[component_idx]
+
+  parts <- lapply(component_names, function(nm) as.character(df[[nm]]))
+  composite_value <- do.call(paste0, parts)
+
+  # paste0() turns NA into the literal string "NA"; honour the documented
+  # contract that any-NA-component yields NA composite.
+  any_na <- Reduce(`|`, lapply(parts, is.na))
+  composite_value[any_na] <- NA_character_
+
+  df[[composite_name]] <- composite_value
+  df
+}
+
+
 #' @title common_fwf_req
 #'
 #' @description common fwf logic across various assessment types.  DRY.
+#'
+#' Detects redundant composite fields (see `find_redundant_overlaps()`),
+#' parses the deduplicated layout via `readr::read_fwf()`, then reconstructs
+#' the dropped composites from their component parts so that downstream
+#' code receives a data frame with the same column count and order as the
+#' full layout.
+#'
 #' @param url file location
 #' @param layout data frame containing fixed-width file column specifications
 #' @return layout layout to use
@@ -396,37 +525,56 @@ common_fwf_req <- function(url, layout) {
   raw_fwf <- iconv(raw_fwf, "LATIN2", "UTF-8")
   num_lines <- lapply(raw_fwf, nchar) %>% unlist()
 
-  #if everything is consistent, great.  if the fwf is ragged, trim whitespace.  
+  #if everything is consistent, great.  if the fwf is ragged, trim whitespace.
   if (any(num_lines < max(num_lines))) {
     raw_fwf <- raw_fwf %>% gsub("[[:space:]]*$","", .)
   }
-  
+
   #check that incoming response (when cleaned) is of consistent length.
   if (!nchar(raw_fwf) %>% unique() %>% length() == 1) {
     warning("the fixed width input file is not fixed - rows are of different length.")
-    warning("truncating rows that are too wide, and padding rows that are too short...")    
+    warning("truncating rows that are too wide, and padding rows that are too short...")
   }
-  
+
   #sometimes the raw response is too short.  that wrecks havoc with read_fwf
-  #additionally, some layouts call for data that there is data that really isnt there.  
-  #(aka science).      
+  #additionally, some layouts call for data that there is data that really isnt there.
+  #(aka science).
   #right pad them to the full extent of the array OR layout
   max_extent <- max(nchar(raw_fwf), max(layout$field_end_position))
   raw_fwf <- sprintf(paste0('%-', max_extent, 's'), raw_fwf)
-  
+
+  # Detect and drop redundant composite fields (the composite county-
+  # district-school identifier, plus any RECORD_KEY) that overlap their
+  # decomposed parts. readr::fwf_positions() rejects any overlap; we
+  # reconstruct the composites post-parse from their parts.
+  redundant <- find_redundant_overlaps(layout)
+  parse_layout <- layout[!redundant, , drop = FALSE]
+
   #read_fwf
   df <- readr::read_fwf(
     file = raw_fwf %>% paste(collapse = '\n'),
     col_positions = readr::fwf_positions(
-      start = layout$field_start_position,
-      end = layout$field_end_position,
-      col_names = layout$final_name
+      start = parse_layout$field_start_position,
+      end = parse_layout$field_end_position,
+      col_names = parse_layout$final_name
     ),
-    col_types = nj_coltype_parser(layout$data_type),
+    col_types = nj_coltype_parser(parse_layout$data_type),
     na = "*",
     progress = TRUE
   )
-  
+
+  # Reconstruct dropped composite fields by concatenating their component
+  # parts, then reorder columns to match the full layout so downstream
+  # positional indexing (e.g. process_nj_assess() implied-decimal mask)
+  # still aligns.
+  redundant_idx <- which(redundant)
+  for (i in redundant_idx) {
+    df <- reconstruct_composite_field(df, layout[i, , drop = FALSE], parse_layout)
+  }
+  if (length(redundant_idx) > 0L) {
+    df <- df[, layout$final_name, drop = FALSE]
+  }
+
   if (!nrow(df) == length(raw_fwf)) {
     paste('read_fwf is', nrow(df), 'lines') %>% print()
     paste('raw response', length(raw_fwf), 'lines') %>% print()

--- a/man/common_fwf_req.Rd
+++ b/man/common_fwf_req.Rd
@@ -16,5 +16,11 @@ layout layout to use
 }
 \description{
 common fwf logic across various assessment types.  DRY.
+
+Detects redundant composite fields (see `find_redundant_overlaps()`),
+parses the deduplicated layout via `readr::read_fwf()`, then reconstructs
+the dropped composites from their component parts so that downstream
+code receives a data frame with the same column count and order as the
+full layout.
 }
 \keyword{internal}

--- a/tests/testthat/test-layout-overlap.R
+++ b/tests/testthat/test-layout-overlap.R
@@ -1,0 +1,431 @@
+# test-layout-overlap.R
+#
+# Regression tests for GitHub issues #47 and #53 — readr::fwf_positions()
+# rejected the legacy NJASK/HSPA/GEPA layouts because every layout encodes
+# the composite CDS_Code (positions 1-9) AND its decomposed parts
+# (County_Code 1-2, District_Code 3-6, School_Code 7-9). Several layouts also
+# carry a RECORD_KEY (positions 1-9) that overlaps the same range.
+#
+# The fix lives in R/fetch_nj_assess.R as two private helpers:
+#   - find_redundant_overlaps(layout) -> logical(nrow(layout))
+#   - reconstruct_composite_field(df, composite_row, parse_layout) -> df
+#
+# These tests are FULLY STRUCTURAL — no real legacy assessment data is
+# downloaded or parsed. The legacy state.nj.us URLs are 404, and there is no
+# archived FWF data in the package (verified during planning). The tests
+# prove that the deduplicated layout is parseable, the reconstruction is
+# correct, and the on-disk .rda metadata is preserved.
+
+LAYOUTS_WITH_OVERLAP <- c(
+  "layout_hspa", "layout_njask",
+  "layout_hspa04", "layout_hspa05", "layout_hspa06", "layout_hspa10",
+  "layout_njask04", "layout_njask05",
+  "layout_njask06gr3", "layout_njask06gr5",
+  "layout_njask07gr3", "layout_njask07gr5",
+  "layout_njask09", "layout_njask10",
+  "layout_gepa", "layout_gepa05", "layout_gepa06"
+)
+
+# Pinned overlap-pair counts from the Phase 0 audit. Acts as a regression
+# guard — if a future contributor hand-edits a layout, this test surfaces it.
+EXPECTED_OVERLAP_PAIRS <- list(
+  layout_hspa = 7L,
+  layout_njask = 3L,
+  layout_hspa04 = 7L,
+  layout_hspa05 = 7L,
+  layout_hspa06 = 7L,
+  layout_hspa10 = 7L,
+  layout_njask04 = 3L,
+  layout_njask05 = 3L,
+  layout_njask06gr3 = 3L,
+  layout_njask06gr5 = 7L,
+  layout_njask07gr3 = 3L,
+  layout_njask07gr5 = 7L,
+  layout_njask09 = 3L,
+  layout_njask10 = 3L,
+  layout_gepa = 3L,
+  layout_gepa05 = 3L,
+  layout_gepa06 = 3L
+)
+
+# Pinned full-layout row counts. Helpful because the fix MUST preserve the
+# total column count downstream — process_nj_assess() addresses df by
+# positional index into layout.
+EXPECTED_LAYOUT_ROWS <- list(
+  layout_hspa = 559L, layout_njask = 551L,
+  layout_hspa04 = 439L, layout_hspa05 = 463L,
+  layout_hspa06 = 511L, layout_hspa10 = 527L,
+  layout_njask04 = 362L, layout_njask05 = 435L,
+  layout_njask06gr3 = 460L, layout_njask06gr5 = 463L,
+  layout_njask07gr3 = 486L, layout_njask07gr5 = 523L,
+  layout_njask09 = 524L, layout_njask10 = 524L,
+  layout_gepa = 486L, layout_gepa05 = 383L, layout_gepa06 = 461L
+)
+
+count_overlap_pairs <- function(layout) {
+  n <- nrow(layout)
+  if (n < 2) return(0L)
+  count <- 0L
+  for (i in seq_len(n - 1)) {
+    for (j in (i + 1):n) {
+      a_s <- layout$field_start_position[i]
+      a_e <- layout$field_end_position[i]
+      b_s <- layout$field_start_position[j]
+      b_e <- layout$field_end_position[j]
+      if (a_s <= b_e && b_s <= a_e) count <- count + 1L
+    }
+  }
+  count
+}
+
+intervals_strictly_disjoint <- function(layout) {
+  if (nrow(layout) < 2) return(TRUE)
+  ord <- order(layout$field_start_position)
+  s <- layout$field_start_position[ord]
+  e <- layout$field_end_position[ord]
+  all(e[-length(e)] < s[-1])
+}
+
+
+# -----------------------------------------------------------------------------
+# Block A: Layout overlap inventory (regression guard)
+# -----------------------------------------------------------------------------
+
+test_that("Block A: every legacy layout has the expected overlap-pair count", {
+  for (nm in LAYOUTS_WITH_OVERLAP) {
+    expect_true(exists(nm), info = paste("layout missing:", nm))
+    lo <- get(nm)
+    expect_equal(
+      nrow(lo), EXPECTED_LAYOUT_ROWS[[nm]],
+      info = paste(nm, "row count drifted")
+    )
+    expect_equal(
+      count_overlap_pairs(lo), EXPECTED_OVERLAP_PAIRS[[nm]],
+      info = paste(nm, "overlap-pair count drifted")
+    )
+  }
+})
+
+
+# -----------------------------------------------------------------------------
+# Block B: Deduplication correctness via find_redundant_overlaps()
+# -----------------------------------------------------------------------------
+
+test_that("Block B: find_redundant_overlaps drops CDS_Code, keeps the parts", {
+  synth <- data.frame(
+    field_start_position = c(1, 1, 3, 7, 10),
+    field_end_position   = c(9, 2, 6, 9, 59),
+    final_name = c("CDS_Code", "County_Code", "District_Code",
+                   "School_Code", "County_Name"),
+    stringsAsFactors = FALSE
+  )
+
+  redundant <- find_redundant_overlaps(synth)
+
+  expect_type(redundant, "logical")
+  expect_length(redundant, 5L)
+  expect_equal(redundant, c(TRUE, FALSE, FALSE, FALSE, FALSE))
+
+  parse_layout <- synth[!redundant, ]
+  expect_true(intervals_strictly_disjoint(parse_layout))
+  expect_equal(nrow(parse_layout), 4L)
+
+  # fwf_positions construction must succeed — this is the exact #47/#53 fix
+  expect_no_error(
+    readr::fwf_positions(
+      start = parse_layout$field_start_position,
+      end   = parse_layout$field_end_position,
+      col_names = parse_layout$final_name
+    )
+  )
+})
+
+test_that("Block B: find_redundant_overlaps drops BOTH CDS_Code and RECORD_KEY", {
+  # Mirrors the layout_hspa / layout_hspa04 / etc. pattern: two composite
+  # fields (RECORD_KEY and CDS_Code) both spanning positions 1-9, plus the
+  # three components.
+  synth <- data.frame(
+    field_start_position = c(1, 1, 1, 3, 7, 10),
+    field_end_position   = c(9, 9, 2, 6, 9, 59),
+    final_name = c("RECORD_KEY", "CDS_Code", "County_Code",
+                   "District_Code", "School_Code", "County_Name"),
+    stringsAsFactors = FALSE
+  )
+
+  redundant <- find_redundant_overlaps(synth)
+
+  expect_length(redundant, 6L)
+  expect_equal(redundant, c(TRUE, TRUE, FALSE, FALSE, FALSE, FALSE))
+
+  parse_layout <- synth[!redundant, ]
+  expect_true(intervals_strictly_disjoint(parse_layout))
+})
+
+test_that("Block B: find_redundant_overlaps is order-independent (gepa05 pattern)", {
+  # layout_gepa05 carries County_Code BEFORE CDS_Code. Detection must work
+  # positionally, not by row order.
+  synth <- data.frame(
+    field_start_position = c(1, 1, 3, 7, 10),
+    field_end_position   = c(2, 9, 6, 9, 59),
+    final_name = c("County_Code", "CDS_Code", "District_Code",
+                   "School_Code", "County_Name"),
+    stringsAsFactors = FALSE
+  )
+
+  redundant <- find_redundant_overlaps(synth)
+
+  expect_length(redundant, 5L)
+  expect_equal(redundant, c(FALSE, TRUE, FALSE, FALSE, FALSE))
+  expect_true(intervals_strictly_disjoint(synth[!redundant, ]))
+})
+
+test_that("Block B: find_redundant_overlaps returns FALSE when no overlaps", {
+  clean <- data.frame(
+    field_start_position = c(1, 3, 7, 10),
+    field_end_position   = c(2, 6, 9, 59),
+    final_name = c("County_Code", "District_Code", "School_Code", "County_Name"),
+    stringsAsFactors = FALSE
+  )
+
+  redundant <- find_redundant_overlaps(clean)
+
+  expect_length(redundant, 4L)
+  expect_false(any(redundant))
+  expect_true(intervals_strictly_disjoint(clean))
+})
+
+
+# -----------------------------------------------------------------------------
+# Block C: Reconstruction correctness via reconstruct_composite_field()
+# -----------------------------------------------------------------------------
+
+test_that("Block C: composite field is reconstructed by concatenating the parts", {
+  # Layout fragment matching the standard CDS_Code pattern. parse_layout is
+  # the deduplicated layout (CDS_Code dropped); composite_row describes the
+  # dropped composite.
+  parse_layout <- data.frame(
+    field_start_position = c(1, 3, 7),
+    field_end_position   = c(2, 6, 9),
+    final_name = c("County_Code", "District_Code", "School_Code"),
+    stringsAsFactors = FALSE
+  )
+  composite_row <- data.frame(
+    field_start_position = 1,
+    field_end_position   = 9,
+    final_name = "CDS_Code",
+    stringsAsFactors = FALSE
+  )
+
+  # Real NJ CDS code — Newark district (county 13, district 3570), Branch
+  # Brook School (school 010). Public directory data, not fabricated.
+  df_parsed <- data.frame(
+    County_Code   = "13",
+    District_Code = "3570",
+    School_Code   = "010",
+    stringsAsFactors = FALSE
+  )
+
+  df_out <- reconstruct_composite_field(df_parsed, composite_row, parse_layout)
+
+  expect_true("CDS_Code" %in% names(df_out))
+  expect_type(df_out$CDS_Code, "character")
+  expect_equal(df_out$CDS_Code, "133570010")
+  expect_equal(nchar(df_out$CDS_Code), 9L)
+})
+
+test_that("Block C: multi-row reconstruction preserves per-row composition", {
+  parse_layout <- data.frame(
+    field_start_position = c(1, 3, 7),
+    field_end_position   = c(2, 6, 9),
+    final_name = c("County_Code", "District_Code", "School_Code"),
+    stringsAsFactors = FALSE
+  )
+  composite_row <- data.frame(
+    field_start_position = 1,
+    field_end_position   = 9,
+    final_name = "CDS_Code",
+    stringsAsFactors = FALSE
+  )
+
+  # Three real NJ schools in Newark Public Schools (district 3570):
+  #   Branch Brook (010), Camden Street (020), Cleveland (030).
+  df_parsed <- data.frame(
+    County_Code   = c("13", "13", "13"),
+    District_Code = c("3570", "3570", "3570"),
+    School_Code   = c("010", "020", "030"),
+    stringsAsFactors = FALSE
+  )
+
+  df_out <- reconstruct_composite_field(df_parsed, composite_row, parse_layout)
+
+  expect_equal(df_out$CDS_Code, c("133570010", "133570020", "133570030"))
+  expect_true(all(nchar(df_out$CDS_Code) == 9L))
+})
+
+test_that("Block C: NA in any component yields NA composite", {
+  parse_layout <- data.frame(
+    field_start_position = c(1, 3, 7),
+    field_end_position   = c(2, 6, 9),
+    final_name = c("County_Code", "District_Code", "School_Code"),
+    stringsAsFactors = FALSE
+  )
+  composite_row <- data.frame(
+    field_start_position = 1,
+    field_end_position   = 9,
+    final_name = "CDS_Code",
+    stringsAsFactors = FALSE
+  )
+
+  df_parsed <- data.frame(
+    County_Code   = c("13", NA_character_, "13"),
+    District_Code = c("3570", "3570", NA_character_),
+    School_Code   = c("010", "020", "030"),
+    stringsAsFactors = FALSE
+  )
+
+  df_out <- reconstruct_composite_field(df_parsed, composite_row, parse_layout)
+
+  expect_equal(df_out$CDS_Code, c("133570010", NA_character_, NA_character_))
+})
+
+test_that("Block C: reconstruction is also correct for RECORD_KEY", {
+  # RECORD_KEY uses the same positions as CDS_Code in 8 layouts — the helper
+  # must work for either composite name without special-casing.
+  parse_layout <- data.frame(
+    field_start_position = c(1, 3, 7),
+    field_end_position   = c(2, 6, 9),
+    final_name = c("County_Code", "District_Code", "School_Code"),
+    stringsAsFactors = FALSE
+  )
+  composite_row <- data.frame(
+    field_start_position = 1,
+    field_end_position   = 9,
+    final_name = "RECORD_KEY",
+    stringsAsFactors = FALSE
+  )
+
+  df_parsed <- data.frame(
+    County_Code   = "13",
+    District_Code = "3570",
+    School_Code   = "010",
+    stringsAsFactors = FALSE
+  )
+
+  df_out <- reconstruct_composite_field(df_parsed, composite_row, parse_layout)
+
+  expect_true("RECORD_KEY" %in% names(df_out))
+  expect_equal(df_out$RECORD_KEY, "133570010")
+})
+
+
+# -----------------------------------------------------------------------------
+# Block D: End-to-end on every real layout
+# -----------------------------------------------------------------------------
+
+test_that("Block D: every legacy layout deduplicates to a parseable spec", {
+  for (nm in LAYOUTS_WITH_OVERLAP) {
+    lo <- get(nm)
+    redundant <- find_redundant_overlaps(lo)
+    parse_layout <- lo[!redundant, ]
+
+    expect_true(
+      intervals_strictly_disjoint(parse_layout),
+      info = paste(nm, "still has overlaps after dedup")
+    )
+
+    # The direct reproduction-fixed assertion for #47/#53
+    expect_no_error(
+      readr::fwf_positions(
+        start = parse_layout$field_start_position,
+        end   = parse_layout$field_end_position,
+        col_names = parse_layout$final_name
+      ),
+      message = paste("fwf_positions failed for", nm)
+    )
+  }
+})
+
+test_that("Block D: every layout drops exactly the redundant composite rows", {
+  # The expected dropped composites (per Phase 0 audit):
+  #   - layouts with RECORD_KEY: drop both RECORD_KEY and CDS_Code (2 rows)
+  #   - layouts without RECORD_KEY: drop only CDS_Code (1 row)
+  expected_drop_names <- list(
+    layout_hspa        = c("RECORD_KEY", "CDS_Code"),
+    layout_njask       = "CDS_Code",
+    layout_hspa04      = c("RECORD_KEY", "CDS_Code"),
+    layout_hspa05      = c("RECORD_KEY", "CDS_Code"),
+    layout_hspa06      = c("RECORD_KEY", "CDS_Code"),
+    layout_hspa10      = c("RECORD_KEY", "CDS_Code"),
+    layout_njask04     = "CDS_Code",
+    layout_njask05     = "CDS_Code",
+    layout_njask06gr3  = "CDS_Code",
+    layout_njask06gr5  = c("RECORD_KEY", "CDS_Code"),
+    layout_njask07gr3  = "CDS_Code",
+    layout_njask07gr5  = c("RECORD_KEY", "CDS_Code"),
+    layout_njask09     = "CDS_Code",
+    layout_njask10     = "CDS_Code",
+    layout_gepa        = "CDS_Code",
+    layout_gepa05      = "CDS_Code",
+    layout_gepa06      = "CDS_Code"
+  )
+
+  for (nm in names(expected_drop_names)) {
+    lo <- get(nm)
+    redundant <- find_redundant_overlaps(lo)
+    expect_setequal(
+      sort(lo$final_name[redundant]),
+      sort(expected_drop_names[[nm]])
+    )
+  }
+})
+
+
+# -----------------------------------------------------------------------------
+# Block E: Layout .rda integrity — on-disk objects are byte-unchanged
+# -----------------------------------------------------------------------------
+
+test_that("Block E: layout objects are not mutated by the dedup helpers", {
+  for (nm in LAYOUTS_WITH_OVERLAP) {
+    lo_before <- get(nm)
+    digest_before <- digest::digest(lo_before)
+
+    # Exercise both helpers as common_fwf_req() would
+    redundant <- find_redundant_overlaps(lo_before)
+    parse_layout <- lo_before[!redundant, ]
+    # Construct a dummy single-row df with one column per parse_layout row
+    dummy_df <- as.data.frame(
+      matrix("00", nrow = 1, ncol = nrow(parse_layout)),
+      stringsAsFactors = FALSE
+    )
+    names(dummy_df) <- parse_layout$final_name
+    for (i in which(redundant)) {
+      dummy_df <- reconstruct_composite_field(
+        dummy_df, lo_before[i, , drop = FALSE], parse_layout
+      )
+    }
+
+    digest_after <- digest::digest(get(nm))
+    expect_identical(
+      digest_before, digest_after,
+      info = paste(nm, "was mutated")
+    )
+  }
+})
+
+
+# -----------------------------------------------------------------------------
+# Block F: Pre-existing tests still skip cleanly (regression guard)
+# -----------------------------------------------------------------------------
+
+test_that("Block F: valid_call regression — unrelated path still works", {
+  # Sanity check: the fix touches only common_fwf_req(). Other internal
+  # helpers must still behave identically.
+  expect_true(valid_call(2014, 8))
+  expect_false(valid_call(2014, 12))
+  expect_true(valid_call(2007, 8))
+  expect_false(valid_call(2005, 5))
+})
+
+test_that("Block F: nj_coltype_parser regression — sibling helper unchanged", {
+  expect_equal(nj_coltype_parser(c("Text", "Integer", "Decimal")), "cid")
+})


### PR DESCRIPTION
Closes #47.
Closes #53.

## Root cause

All 17 legacy layout `.rda` objects (`layout_hspa`, `layout_njask`, `layout_hspa04`/`05`/`06`/`10`, `layout_njask04`/`05`/`06gr3`/`06gr5`/`07gr3`/`07gr5`/`09`/`10`, `layout_gepa`/`05`/`06`) encode the composite county-district-school identifier (positions 1-9) AND its decomposed parts `County_Code` (1-2), `District_Code` (3-6), `School_Code` (7-9) as separate rows. Eight of them also carry a `RECORD_KEY` row that overlaps the same 1-9 range. `readr::fwf_positions()` rejects any overlap, so `common_fwf_req()` errored before parsing a single byte.

This is the same `"Overlapping specification not supported"` error reported in #47 and #53 in 2018.

## Layout overlap inventory

Audited every legacy layout in `data/`. Every overlap follows one of two patterns (no other patterns found):

| Layout | Pairs | Pattern |
|---|---|---|
| layout_hspa | 7 | RECORD_KEY + composite ID + 3 parts |
| layout_njask | 3 | composite ID + 3 parts |
| layout_hspa04 | 7 | RECORD_KEY + composite ID + 3 parts |
| layout_hspa05 | 7 | RECORD_KEY + composite ID + 3 parts |
| layout_hspa06 | 7 | RECORD_KEY + composite ID + 3 parts |
| layout_hspa10 | 7 | RECORD_KEY + composite ID + 3 parts |
| layout_njask04 | 3 | composite ID + 3 parts |
| layout_njask05 | 3 | composite ID + 3 parts |
| layout_njask06gr3 | 3 | composite ID + 3 parts |
| layout_njask06gr5 | 7 | RECORD_KEY + composite ID + 3 parts |
| layout_njask07gr3 | 3 | composite ID + 3 parts |
| layout_njask07gr5 | 7 | RECORD_KEY + composite ID + 3 parts |
| layout_njask09 | 3 | composite ID + 3 parts |
| layout_njask10 | 3 | composite ID + 3 parts |
| layout_gepa | 3 | composite ID + 3 parts |
| layout_gepa05 | 3 | composite ID + 3 parts (parts before composite by row order) |
| layout_gepa06 | 3 | composite ID + 3 parts |

`layout_gepa05` is the only one where the composite row appears AFTER one of its parts by row order, so the detector is positional rather than row-order based.

## Fix

`common_fwf_req()` now:

1. Calls private `find_redundant_overlaps(layout)` to identify rows whose `[start, end]` interval is the exact disjoint union of two or more strictly-narrower other rows' intervals.
2. Parses the deduplicated `parse_layout` via `readr::read_fwf()`.
3. For each redundant row, calls private `reconstruct_composite_field(df, composite_row, parse_layout)` to rebuild the composite by `paste0()`-concatenating the component columns (any-NA-component yields NA composite).
4. Reorders the resulting columns to match the original full layout, so downstream positional indexing in `process_nj_assess()` still aligns.

The on-disk `.rda` layout objects are unchanged — they remain a faithful description of the upstream NJ DOE FWF format. The parser learns to handle the redundancy.

## Tests

`tests/testthat/test-layout-overlap.R` — 148 assertions across 14 test blocks. Fully structural; no legacy assessment data parsed (legacy `state.nj.us` / `nj.gov/education/schools/achievement/...` URLs are 404 and no archive exists locally).

- Block A: per-layout overlap-pair counts pinned as regression guard (17 layouts × 2 expects)
- Block B: dedup correctness on synthetic CDS-pattern, RECORD_KEY-pattern, gepa05-style-reordered-pattern, and no-overlap clean layout
- Block C: composite reconstruction with real public NJ CDS codes (Newark district 13-3570 schools 010/020/030); NA-handling; RECORD_KEY equivalence
- Block D: end-to-end on every layout — `fwf_positions()` construction succeeds, dropped rows match expected names
- Block E: `digest::digest()` byte-identity of each layout before and after exercising the helpers
- Block F: regression spot-check that `valid_call()` and `nj_coltype_parser()` are untouched

All 148 assertions pass. Targeted regression run (`layout-overlap | fetch_nj_assess | issue_reproductions`) shows 286 passed, 3 pre-existing failures (verified against `master` — unrelated to this change).

## Smoke test

Replayed the 2018 issue commands:

```
standard_assess(2014, 11)   # was issue #47
fetch_njask(2014, 6)        # was issue #53
fetch_old_nj_assess(2014, 11)
```

All three previously errored with `"Overlapping specification not supported. Begin offset (0) must be greater than or equal to previous end offset (9)"`. After the fix, all three error with `"cannot open URL ... HTTP status was '404 Not Found'"` — a separate, pre-existing issue with the upstream NJ DOE URL. The readr overlap error is gone. If/when those legacy URLs come back, the parser is now ready.

## devtools::check()

`0 errors | 0 warnings | 4 notes` (all four notes pre-existing: hidden files in `.claude/`, future file timestamps, top-level files, globalVariables namespace bindings).
