### PR TITLE
Repoint dead RC database URLs (nj.gov/education/spr)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: A Simple Interface for Accessing NJ DOE School Data in R and Python
 Description: R functions (with Python bindings) to import NJ school data,
     including assessment, enrollment, and accountability data from the
     New Jersey Department of Education.
-Version: 0.9.14
+Version: 0.9.15
 Authors@R: person("Andrew", "Martin", role = c("aut","cre"),
     email = "almartin@gmail.com")
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,41 @@
+# njschooldata 0.9.15
+
+## Bug fixes
+
+* `get_one_rc_database()` / `fetch_msgp()` / `get_and_process_msgp()` now
+  resolve again for end_years 2012-2019. NJ DOE retired the
+  `rc.doe.state.nj.us` host (now 301-redirects to `nj.gov/education/spr/`)
+  and removed the `/education/schoolperformance/archive/` tree, so every
+  Performance Report database URL hardcoded in `R/report_card.R` had been
+  returning 404 with no replacement on the public site. The bulk PR
+  databases now live in two places:
+
+  - 2011-12 through 2014-15 (legacy single-workbook era):
+    `nj.gov/education/spr/download/archive/<YYYYYY>/<file>` -- same
+    filenames as the old tree, just a different host path.
+  - 2015-16 through 2018-19 (split school/district workbooks):
+    `nj.gov/education/sprreports/download/DataFiles/<YYYY-YYYY>/`, with
+    `PerformanceReports.xlsx` renamed to `Database_SchoolDetail.xlsx`
+    and `DistrictPerformanceReports.xlsx` renamed to
+    `Database_DistrictStateDetail.xlsx`. 2015-16 has no separate
+    district workbook; the school workbook carries
+    `SchoolMedian`/`DistrictMedian`/`StatewideMedian` columns, which is
+    what `get_and_process_msgp(2016)` already expects.
+
+  `njdoe_base_urls$performance` in `R/config_urls.R` is updated for the
+  same reason. The dead URL pattern in `R/report_card.R:71-75,171-176`
+  was confirmed 404 across all 11 entries; the new pattern was
+  discovered by reading `nj.gov/education/spr/download/script/download.js`
+  (the SPR Download page builds its file list dynamically) and verified
+  with end-to-end fetches for 2012, 2014, 2016, and 2017.
+
+* `tests/testthat/test_msgp.R` now includes `is_charter` in the expected
+  column list for sgp 2016/2017/2018/2019. The `is_charter` flag was
+  added to `get_and_process_msgp()` output in commit `8eb714c8` but the
+  column-name assertions in the test were never updated, so all four
+  `sgp works with <year> data` tests had been failing on master with a
+  spurious "expected[8:10]" mismatch unrelated to the URL fix.
+
 # njschooldata 0.9.14
 
 ## Bug fixes

--- a/R/config_urls.R
+++ b/R/config_urls.R
@@ -17,7 +17,9 @@
 njdoe_base_urls <- list(
   assessment = "https://www.nj.gov/education/assessment/results/reports/",
   schools = "https://www.nj.gov/education/schooldirectory/",
-  performance = "https://rc.doe.state.nj.us/",
+  # rc.doe.state.nj.us was retired; performance reports now live at
+  # /education/spr/ (UI) and /education/sprreports/download/ (bulk data).
+  performance = "https://www.nj.gov/education/spr/",
   data = "https://www.nj.gov/education/data/"
 )
 

--- a/R/report_card.R
+++ b/R/report_card.R
@@ -67,14 +67,27 @@ get_one_rc_database <- function(end_year) {
 
 get_standalone_rc_database <- function(end_year) {
   
+  # NJ DOE retired the rc.doe.state.nj.us host (now 301 -> nj.gov/education/spr/)
+  # and the /education/schoolperformance/archive/ tree (now 404, see meta refresh
+  # at /education/schoolperformance/). Two new patterns took their place:
+  #
+  #   2011-12 -> 2014-15:  /education/spr/download/archive/<YYYYYY>/<file>
+  #                        (filenames preserved from the legacy tree)
+  #   2015-16 -> current:  /education/sprreports/download/DataFiles/<YYYY-YYYY>/
+  #                        Database_SchoolDetail.xlsx (renamed from
+  #                        PerformanceReports.xlsx). 2015-16 has no separate
+  #                        district workbook; the school workbook carries
+  #                        SchoolMedian + DistrictMedian + StatewideMedian
+  #                        columns, which is what get_and_process_msgp(2016)
+  #                        already expects.
   pr_urls <- list(
-    "2016" = "https://rc.doe.state.nj.us/ReportsDatabase/15-16/PerformanceReports.xlsx",
-    "2015" = "https://nj.gov/education/schoolperformance/archive/201415/2015PRDATABASE.xlsx",
-    "2014" = "https://nj.gov/education/schoolperformance/archive/201314/2014%20performance%20report%20database.xlsx",
-    "2013" = "https://nj.gov/education/schoolperformance/archive/201213/nj%20pr13%20database.xlsx",
-    "2012" = "https://nj.gov/education/schoolperformance/archive/201112/nj%20pr12%20database.xlsx"
-    
-    # 2003-2011 report cards deleted
+    "2016" = "https://www.nj.gov/education/sprreports/download/DataFiles/2015-2016/Database_SchoolDetail.xlsx",
+    "2015" = "https://www.nj.gov/education/spr/download/archive/201415/2015PRDATABASE.xlsx",
+    "2014" = "https://www.nj.gov/education/spr/download/archive/201314/2014%20performance%20report%20database.xlsx",
+    "2013" = "https://www.nj.gov/education/spr/download/archive/201213/nj%20pr13%20database.xlsx",
+    "2012" = "https://www.nj.gov/education/spr/download/archive/201112/nj%20pr12%20database.xlsx"
+
+    # 2003-2011 report cards deleted (no archive available on nj.gov or Wayback)
     # "2011" = "http://www.nj.gov/education/reportcard/2011/database/RC11%20database.xls",
     # "2010" = "http://www.nj.gov/education/reportcard/2010/database/RC10%20database.xls",
     # "2009" = "http://www.nj.gov/education/reportcard/2009/database/RC09%20database.xls",
@@ -167,13 +180,17 @@ get_rc_databases <- function(end_year_vector = c(2003:2018)) {
 
 get_merged_rc_database <- function(end_year) {
   
+  # rc.doe.state.nj.us was retired; the merged-format PR databases moved to
+  # /education/sprreports/download/DataFiles/<YYYY-YYYY>/ and were renamed
+  # PerformanceReports.xlsx          -> Database_SchoolDetail.xlsx
+  # DistrictPerformanceReports.xlsx  -> Database_DistrictStateDetail.xlsx
   pr_urls <- list(
-    "sch_2019" = "https://rc.doe.state.nj.us/ReportsDatabase/PerformanceReports.xlsx",
-    "dist_2019" = "https://rc.doe.state.nj.us/ReportsDatabase/DistrictPerformanceReports.xlsx",
-    "sch_2018" = "https://rc.doe.state.nj.us/ReportsDatabase/17-18/PerformanceReports.xlsx",
-    "dist_2018" = "https://rc.doe.state.nj.us/ReportsDatabase/17-18/DistrictPerformanceReports.xlsx",
-    "sch_2017" = "https://rc.doe.state.nj.us/ReportsDatabase/16-17/PerformanceReports.xlsx",
-    "dist_2017" = "https://rc.doe.state.nj.us/ReportsDatabase/16-17/DistrictPerformanceReports.xlsx"
+    "sch_2019"  = "https://www.nj.gov/education/sprreports/download/DataFiles/2018-2019/Database_SchoolDetail.xlsx",
+    "dist_2019" = "https://www.nj.gov/education/sprreports/download/DataFiles/2018-2019/Database_DistrictStateDetail.xlsx",
+    "sch_2018"  = "https://www.nj.gov/education/sprreports/download/DataFiles/2017-2018/Database_SchoolDetail.xlsx",
+    "dist_2018" = "https://www.nj.gov/education/sprreports/download/DataFiles/2017-2018/Database_DistrictStateDetail.xlsx",
+    "sch_2017"  = "https://www.nj.gov/education/sprreports/download/DataFiles/2016-2017/Database_SchoolDetail.xlsx",
+    "dist_2017" = "https://www.nj.gov/education/sprreports/download/DataFiles/2016-2017/Database_DistrictStateDetail.xlsx"
   )
   
   # get district and school df

--- a/tests/testthat/test_msgp.R
+++ b/tests/testthat/test_msgp.R
@@ -11,8 +11,8 @@ test_that("sgp works with 2016 data", {
   expect_equal(
     names(sgp16),
     c("county_id", "district_id", "school_id",
-      "end_year", "subject", "grade", "subgroup", "median_sgp", 
-      "is_district", "is_school")
+      "end_year", "subject", "grade", "subgroup", "median_sgp",
+      "is_district", "is_school", "is_charter")
   )
   
   expect_length(sgp16 %>%
@@ -36,8 +36,8 @@ test_that("sgp works with 2017 data", {
   expect_equal(
     names(sgp17),
     c("county_id", "district_id", "school_id",
-      "end_year", "subject", "grade", "subgroup", "median_sgp", 
-      "is_district", "is_school")
+      "end_year", "subject", "grade", "subgroup", "median_sgp",
+      "is_district", "is_school", "is_charter")
   )
 })
 
@@ -47,9 +47,9 @@ test_that("sgp works with 2018 data", {
   expect_s3_class(sgp18, 'data.frame')
   expect_equal(
     names(sgp18),
-    c("county_id", "district_id", "school_id", 
-      "end_year", "subject", "grade", "subgroup", "median_sgp", 
-      "is_district", "is_school")
+    c("county_id", "district_id", "school_id",
+      "end_year", "subject", "grade", "subgroup", "median_sgp",
+      "is_district", "is_school", "is_charter")
   )
 })
 
@@ -59,9 +59,9 @@ test_that("sgp works with 2019 data", {
    expect_s3_class(sgp19, 'data.frame')
    expect_equal(
       names(sgp19),
-      c("county_id", "district_id", "school_id", 
-        "end_year", "subject", "grade", "subgroup", "median_sgp", 
-        "is_district", "is_school")
+      c("county_id", "district_id", "school_id",
+        "end_year", "subject", "grade", "subgroup", "median_sgp",
+        "is_district", "is_school", "is_charter")
    )
 })
 


### PR DESCRIPTION
## What

Repoints every dead Performance Report database URL in `R/report_card.R`
to its current location on `nj.gov`, so `get_one_rc_database()`,
`fetch_msgp()`, `get_and_process_msgp()`, and anything else downstream
of `get_standalone_rc_database()` / `get_merged_rc_database()` resolve
again for end_years 2012-2019.

## Why

NJ DOE has finished decommissioning the old performance reports
infrastructure:

- `rc.doe.state.nj.us` now 301-redirects to `nj.gov/education/spr/`.
- `nj.gov/education/schoolperformance/` is a meta-refresh stub
  (slated for removal July 2027) and its `archive/` subtree returns
  404.

All 11 PR database URLs hardcoded in `R/report_card.R` (`get_standalone_rc_database` lines 71-75, `get_merged_rc_database` lines 171-176) currently return 404. The new locations are:

- **2011-12 → 2014-15** — `nj.gov/education/spr/download/archive/<YYYYYY>/<file>` — same filenames as the old tree, just a different host path.
- **2015-16 → 2018-19** — `nj.gov/education/sprreports/download/DataFiles/<YYYY-YYYY>/`, with
  - `PerformanceReports.xlsx` → `Database_SchoolDetail.xlsx`
  - `DistrictPerformanceReports.xlsx` → `Database_DistrictStateDetail.xlsx`

2015-16 has no separate district workbook on the new site; the school workbook already carries `SchoolMedian` / `DistrictMedian` / `StatewideMedian` columns, which is exactly what `get_and_process_msgp(2016)` uses.

## How I found the new URLs

The SPR Download page renders its file list with JavaScript. Fetching `nj.gov/education/spr/download/script/download.js` reveals the `baseUrl` (`/education/sprreports/download/`) and the new `Database_*` filenames. Every new URL in this PR was verified live (200 + valid xlsx magic bytes) and the workbooks themselves still parse with the existing sheet-name expectations.

## Tests

`tests/testthat/test_msgp.R` (the canonical end-to-end test for these URLs) now passes — 24/24, 0 failed.

Side effect: that same file had been failing on master for unrelated reasons. The four `sgp works with <year> data` column-name assertions never picked up the `is_charter` flag added in commit `8eb714c8`. This PR adds `is_charter` to the expected column list, since the right way to handle test drift is to fix the assertion, not skip the test.

## Out of scope (filed separately)

This PR does not fix issue #114 (district mSGP for 2014-15) — that data is not in any public NJ DOE source for that era. The 2011-12 through 2014-15 PR databases contain only school-level SGP (verified by inspecting the actual workbooks), and district mSGP from that era was distributed via NJ SMART / NJDOE Homeroom behind district credentials per the [December 2014 release memo](https://www.nj.gov/education/broadcasts/2014/DEC/02/12604/13-14%20Upcoming%20mSGP%20Release%20memo.pdf). Closing #114 with that context will land in a follow-up.
