### PR TITLE
Document district mSGP availability gap (closes #114)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: A Simple Interface for Accessing NJ DOE School Data in R and Python
 Description: R functions (with Python bindings) to import NJ school data,
     including assessment, enrollment, and accountability data from the
     New Jersey Department of Education.
-Version: 0.9.15
+Version: 0.9.16
 Authors@R: person("Andrew", "Martin", role = c("aut","cre"),
     email = "almartin@gmail.com")
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# njschooldata 0.9.16
+
+## Documentation
+
+* `?fetch_msgp` / `?get_and_process_msgp` now document that district-level
+  rows (`is_district == TRUE`) are only produced for `end_year >= 2016`,
+  and that NJ DOE never published district mSGP in the public Performance
+  Report database for 2012-2015. The pre-2016 `sgp` sheet contains only
+  school-level rows (confirmed by inspecting the 2011-12 through 2014-15
+  workbooks and the 2014-15 layout doc); district mSGP summaries from
+  that era were distributed confidentially through NJ SMART / NJDOE
+  Homeroom under TEACHNJ / AchieveNJ and require per-district credentials.
+  The roxygen also corrects the stale "valid values are currently 2012-2018"
+  upper bound to 2012-2019. Closes #114.
+
 # njschooldata 0.9.15
 
 ## Bug fixes

--- a/R/msgp.R
+++ b/R/msgp.R
@@ -1,6 +1,18 @@
 #' Get and Process mSGP data
 #'
-#' @param end_year ending school year.  valid values are currently 2012-2018.
+#' @param end_year ending school year. Valid values are 2012-2019.
+#'
+#'   District-level rows (`is_district == TRUE`) are only produced for
+#'   `end_year >= 2016`. NJ DOE did not publish district mSGP in the
+#'   public Performance Report database for 2012-2015 (the `sgp` sheet
+#'   in those workbooks contains only school-level rows -- see the
+#'   2014-15 layout doc at
+#'   `nj.gov/education/spr/download/archive/201415/nj_pr15_layout.xlsx`).
+#'   Pre-2016 district mSGP summaries were distributed confidentially
+#'   through NJ SMART / NJDOE Homeroom under TEACHNJ / AchieveNJ (see
+#'   the December 2014 release memo at
+#'   `nj.gov/education/broadcasts/2014/DEC/02/12604/`) and require
+#'   per-district credentials. See issue #114 for the full archaeology.
 #'
 #' @return df of msgp data, schoolwide (and district-wide and by grade level, if reported)
 #' @keywords internal

--- a/man/fetch_msgp.Rd
+++ b/man/fetch_msgp.Rd
@@ -7,7 +7,19 @@
 fetch_msgp(end_year)
 }
 \arguments{
-\item{end_year}{ending school year.  valid values are currently 2012-2018.}
+\item{end_year}{ending school year. Valid values are 2012-2019.
+
+  District-level rows (`is_district == TRUE`) are only produced for
+  `end_year >= 2016`. NJ DOE did not publish district mSGP in the
+  public Performance Report database for 2012-2015 (the `sgp` sheet
+  in those workbooks contains only school-level rows -- see the
+  2014-15 layout doc at
+  `nj.gov/education/spr/download/archive/201415/nj_pr15_layout.xlsx`).
+  Pre-2016 district mSGP summaries were distributed confidentially
+  through NJ SMART / NJDOE Homeroom under TEACHNJ / AchieveNJ (see
+  the December 2014 release memo at
+  `nj.gov/education/broadcasts/2014/DEC/02/12604/`) and require
+  per-district credentials. See issue #114 for the full archaeology.}
 }
 \value{
 dataframe with mSGP data for the year

--- a/man/get_and_process_msgp.Rd
+++ b/man/get_and_process_msgp.Rd
@@ -7,7 +7,19 @@
 get_and_process_msgp(end_year)
 }
 \arguments{
-\item{end_year}{ending school year.  valid values are currently 2012-2018.}
+\item{end_year}{ending school year. Valid values are 2012-2019.
+
+  District-level rows (`is_district == TRUE`) are only produced for
+  `end_year >= 2016`. NJ DOE did not publish district mSGP in the
+  public Performance Report database for 2012-2015 (the `sgp` sheet
+  in those workbooks contains only school-level rows -- see the
+  2014-15 layout doc at
+  `nj.gov/education/spr/download/archive/201415/nj_pr15_layout.xlsx`).
+  Pre-2016 district mSGP summaries were distributed confidentially
+  through NJ SMART / NJDOE Homeroom under TEACHNJ / AchieveNJ (see
+  the December 2014 release memo at
+  `nj.gov/education/broadcasts/2014/DEC/02/12604/`) and require
+  per-district credentials. See issue #114 for the full archaeology.}
 }
 \value{
 df of msgp data, schoolwide (and district-wide and by grade level, if reported)


### PR DESCRIPTION
## What

Documents the district mSGP availability gap in `fetch_msgp()` /
`get_and_process_msgp()` and **closes #114** (open since 2019).

## Why

Issue #114 asked whether district mSGP data is available for 2014-15
(comment extends the question to 2012-13 and 2013-14). The answer is
no, and the explanation is now in the roxygen so future users find it
in `?fetch_msgp` instead of having to dig through commit history.

### Evidence (consolidated from the #114 hunt)

The 2011-12 through 2014-15 Performance Report workbooks each ship one
`sgp` sheet with these columns (verified against live downloads):

| End year | `sgp` sheet schema | District-level rows? |
|---|---|---|
| 2011-12 | `CO_CODE, DIST_CODE, SCH_CODE, LA_SGP, M_SGP` | No |
| 2012-13 | `CO_CODE, DIST_CODE, SCH_CODE, LA_SGP, M_SGP` | No |
| 2013-14 | `COUNTY_CODE, DISTRICT_CODE, SCHOOL_CODE, LA_SGP, M_SGP` | No |
| 2014-15 | `COUNTY_CODE, DISTRICT_CODE, SCHOOL_CODE, ELA_SGP, MATH_SGP` | No |

The 2014-15 layout doc ([`nj_pr15_layout.xlsx`](https://www.nj.gov/education/spr/download/archive/201415/nj_pr15_layout.xlsx)) confirms it explicitly: the SGP table is defined as exactly those five school-level fields, full stop. District mSGP first appears in the bulk database in 2015-16, when NJ DOE added `SchoolMedian`/`DistrictMedian`/`StatewideMedian` columns -- which is what the `end_year == 2016` branch in `R/msgp.R` already extracts.

District mSGP summaries for the 2012-13 through 2014-15 era DO exist, but only behind NJ SMART / NJDOE Homeroom login. The [December 2014 mSGP release memo](https://www.nj.gov/education/broadcasts/2014/DEC/02/12604/13-14%20Upcoming%20mSGP%20Release%20memo.pdf) makes this unambiguous: "The reports will include district summaries... [via] confidential 2013-14 teacher mSGP reports from NJ SMART." Confidential educator-evaluation data under TEACHNJ / AchieveNJ -- no public bulk extract, ever. Aggregating school-level mSGP into a district median would be a derivation, not the official NJ DOE number, and would conflict with the project's no-fabrication rule.

## Changes

- `R/msgp.R`: roxygen for `get_and_process_msgp()` updates the year range from `2012-2018` (stale) to `2012-2019` and adds a paragraph on the `is_district >= 2016` gap with links to the layout doc and release memo.
- `man/fetch_msgp.Rd` and `man/get_and_process_msgp.Rd`: regenerated.
- `NEWS.md`: documentation entry for 0.9.16.
- `DESCRIPTION`: version bump 0.9.15 → 0.9.16.

No code-behavior changes.
