### PR TITLE
Fix stale assertions in special pop tests

### DIFF
--- a/tests/testthat/test_special_pop.R
+++ b/tests/testthat/test_special_pop.R
@@ -63,7 +63,7 @@ test_that("ground truth value checks on 2018 special populations data", {
 )
 
 test_that("special populations data is enriched w/ enrollment, 2018", {
-   expect_equal(sp_18 %>%
+   expect_equal(sp18 %>%
                    filter(district_id == '3570',
                           school_id == '220',
                           subgroup == 'Economically Disadvantaged') %>%
@@ -97,8 +97,8 @@ test_that("ground truth value checks on 2019 special populations data", {
                 78.6)
    
    expect_equal(newark_sp_19 %>% 
-                   filter(subgroup == "IEP") %>% 
-                   pull(percent), 
+                   filter(subgroup == "students with disabilities") %>%
+                   pull(percent),
                 29.2)
    
    expect_equal(newark_sp_19 %>% 


### PR DESCRIPTION
Two assertions in `test_special_pop.R` were broken and never matched live data:

- `subgroup == "IEP"` matched 0 rows because `fetch_reportcard_special_pop()` emits the label `students with disabilities`. Updated the filter; the 29.2% Newark (district 3570, school 270, 2019) ground-truth assertion now actually runs.
- `sp_18` was an undefined-variable typo (the fixture is `sp18`), throwing an error in the 2018 enrichment check. Corrected to `sp18`, keeping the 428 econ-disadvantaged count assertion.

Confirmed locally: `devtools::test(filter="special_pop")` -> FAIL 0 | PASS 18.