### PR TITLE
Put full MIT text in LICENSE for correct GitHub license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,21 @@
-YEAR: 2026
-COPYRIGHT HOLDER: Andy Martin
+MIT License
+
+Copyright (c) 2026 Andy Martin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
GitHub's license detector reads the top-priority root file (`LICENSE`), which previously held only the 2-line R template (YEAR + COPYRIGHT HOLDER). That text matches no known license, so GitHub showed "Unknown, MIT licenses found" (it found full MIT only in `LICENSE.md`).

This puts the full MIT text in `LICENSE` itself so the file GitHub reads first resolves cleanly to MIT. Still valid for R: `License: MIT + file LICENSE` only requires the file to exist.