### PR TITLE
Gitignore GOALS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ scratch/
 
 # Claude Code working scratch (PDFs, text dumps, agent context)
 .claude/
+
+# Private business-strategy doc — must NEVER be committed to a public repo
+GOALS.md


### PR DESCRIPTION
Add GOALS.md to .gitignore. This is a public repo, so the private business-strategy doc must never be staged or committed.