### PR TITLE
Profiles: clean share URLs (render at site root)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,8 @@ site/dev-explore.R
 site/dev-explore.out
 site/*_files/
 site/*.out
-site/profiles/
+site/[0-9]*.qmd
+site/*.html
+site/*.rmarkdown
+site/site_libs/
+site/_freeze/

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -2,10 +2,9 @@ project:
   type: website
   output-dir: _site
   execute-dir: project
-  render:
-    - index.qmd
-    - about.qmd
-    - profiles/*.qmd
+  # No explicit render list: Quarto renders index.qmd, about.qmd, and every
+  # generated {district_id}.qmd at the site root, skipping _-prefixed includes.
+  # District stubs at root -> clean URLs at .../profiles/{id}.html.
 
 website:
   title: "NJ District Profiles"
@@ -49,4 +48,4 @@ format:
       echo: true
       warning: false
       message: false
-      freeze: false
+      freeze: auto

--- a/site/index.qmd
+++ b/site/index.qmd
@@ -44,7 +44,7 @@ cat(sprintf("**%s districts** &nbsp;·&nbsp; **%s students** statewide &nbsp;·&
 disp <- tbl %>%
   mutate(District = ifelse(
     district_id %in% built,
-    sprintf('<a href="profiles/%s.html">%s</a>', district_id, district_name),
+    sprintf('<a href="%s.html">%s</a>', district_id, district_name),
     district_name)) %>%
   transmute(District, County = county, Type = type,
             DFG = ifelse(is.na(dfg), "—", dfg),

--- a/site/render-all.R
+++ b/site/render-all.R
@@ -13,8 +13,9 @@ suppressMessages({ library(dplyr) })
 
 SITE_DIR    <- "site"
 BUNDLE_DIR  <- file.path(SITE_DIR, "_bundles")
-PROFILE_DIR <- file.path(SITE_DIR, "profiles")
-dir.create(PROFILE_DIR, showWarnings = FALSE)
+# District stubs render at the site root so pages deploy to
+# .../profiles/{id}.html (clean share URLs), not .../profiles/profiles/{id}.html.
+PROFILE_DIR <- SITE_DIR
 
 dir_all <- readRDS(file.path(BUNDLE_DIR, "_statewide", "directory.rds"))
 name_for <- function(id) {
@@ -42,7 +43,7 @@ subtitle: "New Jersey district profile"
 district_id <- "%s"
 ```
 
-{{< include ../_district-body.qmd >}}
+{{< include _district-body.qmd >}}
 ', yaml_q(name_for(id)), id)
 }
 


### PR DESCRIPTION
Follow-up to #286. District profile pages now render at the site root so they publish to clean URLs like `.../profiles/4900.html` instead of the double-nested `.../profiles/profiles/4900.html`. Drops the explicit render list (Quarto default renders index, about, and all generated stubs), fixes landing-page links, and gitignores render intermediates.

No data or template logic changes.