### PR TITLE
Finance: per-pupil quality guardrails and end_years alias

### DIFF
--- a/R/fetch_finance.R
+++ b/R/fetch_finance.R
@@ -103,6 +103,28 @@ attach_nces_finance <- function(df) {
 }
 
 
+# Cross-state discovery treats per-pupil values above $100k as out-of-range.
+# NJ's source can publish real values above that for county special-services
+# districts; suppress them in the canonical front door rather than rescaling or
+# fabricating a comparable number. Zero denominators on suppressed/blank rows are
+# also source no-data markers, not valid enrollment denominators.
+sanitize_finance_quality <- function(df) {
+  if (is.null(df) || nrow(df) == 0) return(df)
+
+  bad_denominator <- df$is_per_pupil %in% TRUE &
+    !is.na(df$enrollment_denominator) &
+    df$enrollment_denominator <= 0
+  df$enrollment_denominator[bad_denominator] <- NA_real_
+
+  out_of_range_pp <- df$is_per_pupil %in% TRUE &
+    !is.na(df$value) &
+    df$value > 100000
+  df$value[out_of_range_pp] <- NA_real_
+
+  df
+}
+
+
 # ------------------------------------------------------------------------------
 # revenue side: total K-12 state aid per district (and the statewide total)
 # ------------------------------------------------------------------------------
@@ -312,6 +334,7 @@ fetch_finance <- function(end_year, tidy = TRUE, use_cache = TRUE) {
   out$entity_name <- .finance_clean_utf8(out$entity_name)
   out$county      <- .finance_clean_utf8(out$county)
 
+  out <- sanitize_finance_quality(out)
   out <- attach_nces_finance(out)
   out <- out[, .finance_cols, drop = FALSE]
   # the NJ DOE source occasionally repeats a district's row verbatim (e.g. a
@@ -327,6 +350,8 @@ fetch_finance <- function(end_year, tidy = TRUE, use_cache = TRUE) {
 #'
 #' @param end_year_vector vector of school years (end of the academic year). See
 #'   \code{\link{get_available_finance_years}} for valid values.
+#' @param end_years alias for \code{end_year_vector}, used by cross-state
+#'   discovery tooling.
 #' @param tidy logical, default \code{TRUE}. See \code{\link{fetch_finance}}.
 #' @param use_cache logical, default \code{TRUE}. See \code{\link{fetch_finance}}.
 #'
@@ -344,7 +369,20 @@ fetch_finance <- function(end_year, tidy = TRUE, use_cache = TRUE) {
 #' }
 #'
 #' @export
-fetch_finance_multi <- function(end_year_vector, tidy = TRUE, use_cache = TRUE) {
+fetch_finance_multi <- function(end_year_vector = NULL, end_years = NULL,
+                                tidy = TRUE, use_cache = TRUE) {
+  if (is.null(end_year_vector)) {
+    end_year_vector <- end_years
+  } else if (!is.null(end_years) &&
+             !identical(as.integer(end_year_vector), as.integer(end_years))) {
+    stop("Supply either `end_year_vector` or `end_years`, not conflicting values.",
+         call. = FALSE)
+  }
+
+  if (is.null(end_year_vector)) {
+    end_year_vector <- get_available_finance_years()
+  }
+
   purrr::map_dfr(end_year_vector, function(.y) {
     message(.y)
     fetch_finance(.y, tidy = tidy, use_cache = use_cache)

--- a/man/fetch_finance_multi.Rd
+++ b/man/fetch_finance_multi.Rd
@@ -4,11 +4,19 @@
 \alias{fetch_finance_multi}
 \title{Fetch multiple years of NJ school finance}
 \usage{
-fetch_finance_multi(end_year_vector, tidy = TRUE, use_cache = TRUE)
+fetch_finance_multi(
+  end_year_vector = NULL,
+  end_years = NULL,
+  tidy = TRUE,
+  use_cache = TRUE
+)
 }
 \arguments{
 \item{end_year_vector}{vector of school years (end of the academic year). See
 \code{\link{get_available_finance_years}} for valid values.}
+
+\item{end_years}{alias for \code{end_year_vector}, used by cross-state
+discovery tooling.}
 
 \item{tidy}{logical, default \code{TRUE}. See \code{\link{fetch_finance}}.}
 

--- a/tests/testthat/test-finance.R
+++ b/tests/testthat/test-finance.R
@@ -106,6 +106,28 @@ test_that("per_pupil_total carries an enrollment denominator for districts", {
   expect_true(mean(!is.na(d$enrollment_denominator)) > 0.85)
 })
 
+test_that("finance output passes cross-state discovery per-pupil guardrails", {
+  skip_if_not(have_data, "NJ DOE finance source unavailable")
+  pp <- fin[fin$is_per_pupil & !is.na(fin$value), ]
+  expect_equal(sum(pp$value > 100000), 0L)
+
+  f11 <- tryCatch(suppressWarnings(fetch_finance(2011)), error = function(e) NULL)
+  skip_if(is.null(f11) || nrow(f11) == 0, "NJ DOE finance source unavailable")
+  bad_denoms <- f11[f11$is_per_pupil & !is.na(f11$enrollment_denominator) &
+                      f11$enrollment_denominator <= 0, ]
+  expect_equal(nrow(bad_denoms), 0L)
+})
+
+test_that("fetch_finance_multi accepts the cross-state end_years alias", {
+  f <- tryCatch(
+    suppressWarnings(fetch_finance_multi(end_years = c(2024, 2025))),
+    error = function(e) NULL
+  )
+  skip_if(is.null(f) || nrow(f) == 0, "NJ DOE finance source unavailable")
+  expect_true(all(c(2024, 2025) %in% unique(f$end_year)))
+  expect_equal(names(f), finance_cols)
+})
+
 test_that("tidy values match the raw TGES source (fidelity)", {
   skip_if_not(have_data, "NJ DOE finance source unavailable")
   tg <- tryCatch(suppressWarnings(fetch_tges(2025)), error = function(e) NULL)


### PR DESCRIPTION
Adds `sanitize_finance_quality()` to `fetch_finance()`, which suppresses out-of-range per-pupil values (above $100k) and zero/blank enrollment denominators to NA rather than rescaling or substituting a fabricated comparable number. Adds an `end_years` alias to `fetch_finance_multi()` for cross-state tooling.

New finance tests cover both behaviors. All 34 finance tests pass against the live NJ DOE TGES source.