### PR TITLE
Finance: pass through real per-pupil values above $100k

### DIFF
--- a/R/fetch_finance.R
+++ b/R/fetch_finance.R
@@ -103,11 +103,11 @@ attach_nces_finance <- function(df) {
 }
 
 
-# Cross-state discovery treats per-pupil values above $100k as out-of-range.
-# NJ's source can publish real values above that for county special-services
-# districts; suppress them in the canonical front door rather than rescaling or
-# fabricating a comparable number. Zero denominators on suppressed/blank rows are
-# also source no-data markers, not valid enrollment denominators.
+# NJ's source publishes real per-pupil values above $100k for county
+# special-services districts; pass them through unchanged for raw fidelity rather
+# than rescaling, capping, or fabricating a comparable number. The only guard kept
+# here is zero/blank enrollment denominators on per-pupil rows, which are source
+# no-data markers, not valid enrollment denominators.
 sanitize_finance_quality <- function(df) {
   if (is.null(df) || nrow(df) == 0) return(df)
 
@@ -115,11 +115,6 @@ sanitize_finance_quality <- function(df) {
     !is.na(df$enrollment_denominator) &
     df$enrollment_denominator <= 0
   df$enrollment_denominator[bad_denominator] <- NA_real_
-
-  out_of_range_pp <- df$is_per_pupil %in% TRUE &
-    !is.na(df$value) &
-    df$value > 100000
-  df$value[out_of_range_pp] <- NA_real_
 
   df
 }

--- a/tests/testthat/test-finance.R
+++ b/tests/testthat/test-finance.R
@@ -106,11 +106,28 @@ test_that("per_pupil_total carries an enrollment denominator for districts", {
   expect_true(mean(!is.na(d$enrollment_denominator)) > 0.85)
 })
 
-test_that("finance output passes cross-state discovery per-pupil guardrails", {
+test_that("real per-pupil values above $100k pass through with raw fidelity", {
   skip_if_not(have_data, "NJ DOE finance source unavailable")
+  # County special-services districts genuinely spend more than $100k per pupil.
+  # These were formerly NA-ed by a blunt magnitude cap; the canonical front door
+  # now passes them through unchanged so the value matches the published source.
   pp <- fin[fin$is_per_pupil & !is.na(fin$value), ]
-  expect_equal(sum(pp$value > 100000), 0L)
+  expect_true(any(pp$value > 100000))
 
+  bergen <- fin$value[which(fin$state_id == "0285" &
+                              fin$metric == "per_pupil_total")]
+  expect_true(length(bergen) == 1 && bergen > 100000)
+
+  tg <- tryCatch(suppressWarnings(fetch_tges(2025)), error = function(e) NULL)
+  skip_if(is.null(tg), "TGES source unavailable")
+  aa <- tg[["CSG1AA_AVGS"]]
+  raw <- aa[which(aa$end_year == 2024 & aa$calc_type == "Actuals" &
+                    aa$district_id == "0285"), "Per Pupil Total Expenditures",
+            drop = TRUE]
+  expect_equal(as.numeric(bergen), as.numeric(raw[1]))
+})
+
+test_that("zero/blank per-pupil denominators are still NA-ed", {
   f11 <- tryCatch(suppressWarnings(fetch_finance(2011)), error = function(e) NULL)
   skip_if(is.null(f11) || nrow(f11) == 0, "NJ DOE finance source unavailable")
   bad_denoms <- f11[f11$is_per_pupil & !is.na(f11$enrollment_denominator) &


### PR DESCRIPTION
Removes the blunt $100,000 per-pupil magnitude ceiling in `sanitize_finance_quality()` so legitimate published per-pupil spending passes through with raw fidelity.

## What changed
- **Removed** the `value > 100000` suppression branch that NA-ed real per-pupil values for county special-services districts (Bergen, Mercer, Burlington), which genuinely spend above $100k per pupil.
- **Kept** the zero/blank `enrollment_denominator` guard on per-pupil rows (those are source no-data markers, not valid denominators).

## Tests
- Replaced the old `>$100k = 0 rows` guardrail assertion (which encoded the removed cap) with a fidelity test: Bergen Co Special Service (state_id 0285) per-pupil total now passes through at $121,223 and matches the published TGES source.
- Retained the bad-denominator test and the `end_years` alias test.
- All 36 finance tests pass locally.