### PR TITLE
Fix stale enrollment column-count assertions (NCES columns)

### DIFF
--- a/tests/testthat/test-enrollment-year-coverage.R
+++ b/tests/testthat/test-enrollment-year-coverage.R
@@ -14,18 +14,20 @@
 
 wide_test_years <- list(
   # year, expected_cols, min_rows
-  # Pre-2020 format: separate program codes, ~26k rows, 39 cols
-  list(year = 2015, min_rows = 25000, expected_cols = 39),
-  list(year = 2018, min_rows = 25000, expected_cols = 39),
-  list(year = 2019, min_rows = 25000, expected_cols = 39),
-  # Post-2020 format: State/District/School sheets, ~57k rows, 26 cols
-  list(year = 2020, min_rows = 50000, expected_cols = 26),
-  list(year = 2021, min_rows = 50000, expected_cols = 26),
-  list(year = 2022, min_rows = 50000, expected_cols = 26),
+  # expected_cols includes the 2 NCES id columns (nces_dist, nces_sch) that
+  # fetch_enr() attaches to every result.
+  # Pre-2020 format: separate program codes, ~26k rows, 39 + 2 NCES = 41 cols
+  list(year = 2015, min_rows = 25000, expected_cols = 41),
+  list(year = 2018, min_rows = 25000, expected_cols = 41),
+  list(year = 2019, min_rows = 25000, expected_cols = 41),
+  # Post-2020 format: State/District/School sheets, ~57k rows, 26 + 2 NCES = 28 cols
+  list(year = 2020, min_rows = 50000, expected_cols = 28),
+  list(year = 2021, min_rows = 50000, expected_cols = 28),
+  list(year = 2022, min_rows = 50000, expected_cols = 28),
   # 2024+ ships ~101k rows (Ungraded column dropped, more school rows)
-  list(year = 2025, min_rows = 50000, expected_cols = 26),
+  list(year = 2025, min_rows = 50000, expected_cols = 28),
   # 2025-26 file shipped as "Enrollment_2526.zip" (capital E - filename case flip)
-  list(year = 2026, min_rows = 50000, expected_cols = 26)
+  list(year = 2026, min_rows = 50000, expected_cols = 28)
 )
 
 for (spec in wide_test_years) {

--- a/tests/testthat/test_enr.R
+++ b/tests/testthat/test_enr.R
@@ -41,7 +41,7 @@ test_that("fetch_enr correctly grabs the 2009 enrollment file", {
   fetch_2009 <- fetch_enr(2009)
 
   expect_equal(nrow(fetch_2009), 29491)
-  expect_equal(ncol(fetch_2009), 39)
+  expect_equal(ncol(fetch_2009), 41)  # 39 data + 2 NCES id cols (nces_dist, nces_sch)
   # Verified against raw NJ DOE source file: enrollment_0809.zip -> STAT_ENR.CSV
   expect_equal(sum(as.numeric(fetch_2009$row_total), na.rm = TRUE), 11034082)
 })
@@ -52,7 +52,7 @@ test_that("fetch_enr handles the 2016-17 enrollment file", {
 
   expect_s3_class(fetch_2017, 'data.frame')
   expect_equal(nrow(fetch_2017), 26467)
-  expect_equal(ncol(fetch_2017), 39)
+  expect_equal(ncol(fetch_2017), 41)  # 39 data + 2 NCES id cols (nces_dist, nces_sch)
 })
 
 
@@ -61,7 +61,7 @@ test_that("fetch_enr handles the 2017-18 enrollment file", {
 
   expect_s3_class(fetch_2018, 'data.frame')
   expect_equal(nrow(fetch_2018), 26484)
-  expect_equal(ncol(fetch_2018), 39)
+  expect_equal(ncol(fetch_2018), 41)  # 39 data + 2 NCES id cols (nces_dist, nces_sch)
 })
 
 
@@ -78,7 +78,7 @@ test_that("fetch_enr handles the 2017-18 enrollment file, tidy TRUE", {
                   nrow(), 6e5)
   
   expect_equal(nrow(fetch_2018), 651701)
-  expect_equal(ncol(fetch_2018), 22)  # includes is_charter column
+  expect_equal(ncol(fetch_2018), 24)  # 22 data (incl is_charter) + 2 NCES id cols (nces_dist, nces_sch)
 })
 
 
@@ -88,7 +88,7 @@ test_that("fetch_enr handles the 2018-19 enrollment file", {
   expect_s3_class(fetch_2019, 'data.frame')
   
   expect_equal(nrow(fetch_2019), 26506)
-  expect_equal(ncol(fetch_2019), 39)
+  expect_equal(ncol(fetch_2019), 41)  # 39 data + 2 NCES id cols (nces_dist, nces_sch)
 })
 
 test_that("fetch_enr handles the 2018-19 enrollment file, tidy = TRUE", {
@@ -96,7 +96,7 @@ test_that("fetch_enr handles the 2018-19 enrollment file, tidy = TRUE", {
   
   expect_s3_class(fetch_2019, 'data.frame')
   expect_equal(nrow(fetch_2019), 652214)
-  expect_equal(ncol(fetch_2019), 22)  # includes is_charter column
+  expect_equal(ncol(fetch_2019), 24)  # 22 data (incl is_charter) + 2 NCES id cols (nces_dist, nces_sch)
 })
 
 
@@ -108,7 +108,7 @@ test_that("all enrollment data can be pulled", {
 
   expect_s3_class(enr_all, 'data.frame')
   expect_equal(nrow(enr_all), 727779)
-  expect_equal(ncol(enr_all), 42)
+  expect_equal(ncol(enr_all), 44)  # 42 data + 2 NCES id cols (nces_dist, nces_sch)
 })
 
 


### PR DESCRIPTION
PR #289 added two federal NCES id columns (`nces_dist`, `nces_sch`) to `fetch_enr()` output on both the wide and tidy paths (via `attach_nces_ids()`), but the older column-count assertions were never updated, so they were off by +2 and failed when run online. CI is network-gated for these tests, so it went unnoticed.

Corrected each affected `ncol()`/`expected_cols` assertion to its live-verified count:

- Wide pre-2020: 39 -> 41 (2009, 2015, 2017, 2018, 2019)
- Wide post-2020: 26 -> 28 (2020, 2021, 2022, 2025, 2026)
- Tidy: 22 -> 24 (2018, 2019)
- `map_df(2000:2022)` bound frame: 42 -> 44

Each count was confirmed by running the actual fetch and reading `ncol()` (all exactly +2). `get_raw_enr()` assertions were left unchanged (raw layer does not get NCES columns).

Note: a few pre-existing `nrow` assertions in test_enr.R are stale from NJ DOE file republishing (unrelated to NCES columns, which add columns not rows) and are intentionally out of scope here.