### PR TITLE
Separate data and plot chunk caching to prevent silent figure loss

### DIFF
--- a/dev-docs/vignette-authoring.md
+++ b/dev-docs/vignette-authoring.md
@@ -42,3 +42,48 @@ failed because neither touched the committed figure binaries.
 - Do **not** commit `vignettes/<vignette>_cache/` directories. Cached plot chunks
   replay stale figures across build environments (the caschooldata 2026-03
   incident); keeping plots un-cached forces a fresh render every time.
+
+## Data vs Plot Chunk Separation (REQUIRED)
+
+**NEVER put data-fetching and ggplot code in the same cached chunk.** knitr
+chunk caching does not reliably replay figure output across environments. When
+a cached chunk's figure files aren't found, knitr silently drops them —
+producing HTML with code but no charts.
+
+**Pattern:**
+- Data-fetching chunks: `cache = TRUE` — expensive downloads are cached.
+- Plot chunks: `cache = FALSE` (or inherit the global default) — always
+  re-evaluated, always produce figures.
+
+**Example (correct):**
+```r
+```{r fetch-data, cache=TRUE}
+enr <- fetch_enr_multi(2018:2025, use_cache = TRUE)
+```
+
+```{r state-trend-chart}
+# cache = FALSE inherited from global default
+ggplot(state_trend, aes(x = end_year, y = n_students)) + ...
+```
+```
+
+**Example (broken — DO NOT DO):**
+```r
+```{r finding-1}
+# cache = TRUE inherited — THIS BREAKS FIGURE OUTPUT IN CI
+state_trend <- enr %>% filter(...)
+ggplot(state_trend, ...) + ...
+```
+```
+
+**If a single chunk both fetches data and plots, split it:** give the new
+fetch-only chunk a new label with `cache = TRUE`, and keep the plotting code
+under the ORIGINAL chunk label (figure filenames derive from the chunk label,
+and README images reference them, so plot chunk labels must not change).
+
+**INCIDENT REFERENCE (caschooldata, 2026-03):** All 5 CA vignettes had
+`cache = TRUE` globally. pkgdown CI builds produced HTML with zero `<img>`
+tags — ggplot code displayed but no rendered charts. Figure PNG files existed
+on gh-pages (from earlier builds with `clean: false`) but were never
+referenced by the HTML. Fixed by changing the global default to
+`cache = FALSE` and adding explicit `cache = TRUE` only on data-fetch chunks.

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -13,7 +13,9 @@ knitr::opts_chunk$set(
   comment = "#>",
   message = FALSE,
   warning = FALSE,
-  cache = TRUE
+  # Default OFF: only individual fetch chunks cache. A global cache=TRUE lets
+  # knitr silently drop figure output on cache hits (caschooldata, 2026-03).
+  cache = FALSE
 )
 ```
 
@@ -86,7 +88,7 @@ Data is provided at multiple aggregation levels, identified by boolean flags:
 
 ### Fetching Basic Enrollment
 
-```{r enrollment-basic}
+```{r enrollment-basic, cache = TRUE}
 # Get 2024 enrollment data (2023-24 school year)
 enr_2024 <- fetch_enr(2024)
 
@@ -100,7 +102,7 @@ dim(enr_2024)  # Rows and columns
 ### Wide vs. Tidy Format
 
 The `tidy` parameter transforms data for easier analysis:
-```{r enrollment-tidy}
+```{r enrollment-tidy, cache = TRUE}
 # Wide format (default) - one row per school, many demographic columns
 enr_wide <- fetch_enr(2024, tidy = FALSE)
 
@@ -135,7 +137,7 @@ state_totals <- enr_tidy %>%
 
 Use `fetch_parcc()` for both NJSLA (2019+) and PARCC (2015-2018) data:
 
-```{r assessment}
+```{r assessment, cache = TRUE}
 # Get 2024 Grade 4 Math results
 math_g4_2024 <- fetch_parcc(
   end_year = 2024,
@@ -185,7 +187,7 @@ njask_2010 <- fetch_old_nj_assess(
 
 ### Graduation Rates
 
-```{r graduation-rates}
+```{r graduation-rates, cache = TRUE}
 # Get 4-year graduation rates for 2024
 grad_rate_2024 <- fetch_grad_rate(
   end_year = 2024,
@@ -201,7 +203,7 @@ grad_rate_5yr <- fetch_grad_rate(
 
 ### Graduation Counts
 
-```{r graduation-counts}
+```{r graduation-counts, cache = TRUE}
 # Get graduation counts
 grad_count_2024 <- fetch_grad_count(end_year = 2024)
 ```
@@ -280,7 +282,7 @@ reliable_data <- enr_tidy %>%
 
 Use `purrr::map_df()` for combining multiple years:
 
-```{r multi-year}
+```{r multi-year, cache = TRUE}
 library(purrr)
 
 # Fetch 5 years of enrollment data


### PR DESCRIPTION
## Summary

- getting-started.Rmd had global `cache = TRUE` in its knitr setup chunk, the vignette-cache anti-pattern that can silently drop rendered figures on cache hits (see the caschooldata 2026-03 incident). Every other vignette in this package already used the correct pattern (global `cache = FALSE`, `cache = TRUE` only on the data-fetch chunk).
- Flipped the global default to `cache = FALSE` and marked the six fetch_*-calling chunks (`enrollment-basic`, `enrollment-tidy`, `assessment`, `graduation-rates`, `graduation-counts`, `multi-year`) with explicit `cache = TRUE`, matching the convention used elsewhere in the package. This vignette has no ggplot chunks, so there was no live broken-figure bug, but the global setting was still the anti-pattern and is now consistent with the rest of the fleet.
- Added a "Data vs Plot Chunk Separation (REQUIRED)" section to `dev-docs/vignette-authoring.md` documenting the rule, the split-chunk recipe, and the caschooldata incident, alongside the existing "knitr Cache Discipline" section.

## Test plan

- Source-only change; no data pipeline or R code touched.
- Verified via script that no chunk with `cache = TRUE` anywhere in `vignettes/*.Rmd` contains a `ggplot(` call.