### PR TITLE
Fix pkgdown reference index: remove stale directory function topics

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -139,9 +139,6 @@ reference:
     desc: Functions for school and district metadata
     contents:
       - fetch_directory
-      - clear_directory_cache
-      - get_school_directory
-      - get_district_directory
 
   - title: Charter Aggregations
     desc: Functions for charter school sector aggregations


### PR DESCRIPTION
clear_directory_cache, get_school_directory, and get_district_directory no longer exist in R/ (removed during the directory-contract/v1 conversion) but were still listed in _pkgdown.yml, which aborts the pkgdown build on the first unresolved topic. Removed all three lines; fetch_directory remains in the section.

Verified with pkgdown::check_pkgdown() -> No problems found.