### PR TITLE
Fix: restore reproducible documentation builds

### DIFF
--- a/R/fetch_staff_doedata.R
+++ b/R/fetch_staff_doedata.R
@@ -402,21 +402,34 @@ certificated_staff_source <- function(end_year) {
 #'
 #' @param end_year A covered school year end.
 #' @param work_dir A scratch directory the caller owns and cleans up.
+#' @param download_fn Download function with the same arguments used by
+#'   \code{downloader::download}. Exposed for deterministic offline testing.
 #' @return A list with \code{path}, \code{era}.
 #' @keywords internal
-certificated_staff_local_file <- function(end_year, work_dir) {
+certificated_staff_local_file <- function(
+    end_year,
+    work_dir,
+    download_fn = downloader::download) {
   src <- certificated_staff_source(end_year)
   ext <- if (src$archive) ".zip" else ".xlsx"
   dest <- file.path(work_dir, paste0("cert_", end_year, ext))
-  downloader::download(src$url, destfile = dest, mode = "wb")
+  download_fn(src$url, destfile = dest, mode = "wb")
 
-  if (!is_valid_xlsx(dest)) {
+  validation <- tryCatch(
+    {
+      .validate_source_file(dest, if (src$archive) "zip" else "xlsx")
+      NULL
+    },
+    error = identity
+  )
+  if (inherits(validation, "error")) {
     stop(sprintf(
       paste0(
         "Downloaded certificated-staff file for %d is not a valid archive/workbook ",
-        "-- the NJ DOE source may be unavailable or returned an error page.\n  URL: %s"
+        "-- the NJ DOE source may be unavailable or returned an error page.\n",
+        "  URL: %s\n  Validation error: %s"
       ),
-      end_year, src$url
+      end_year, src$url, conditionMessage(validation)
     ), call. = FALSE)
   }
 
@@ -748,8 +761,8 @@ fetch_certificated_staff <- function(end_year, level = "school") {
   cached <- cache_get(cache_key)
   if (!is.null(cached)) return(cached)
 
-  work_dir <- file.path(tempdir(), paste0("njcert_", end_year, "_", as.integer(stats::runif(1, 1, 1e6))))
-  dir.create(work_dir, recursive = TRUE, showWarnings = FALSE)
+  work_dir <- tempfile(pattern = paste0("njcert_", end_year, "_"))
+  dir.create(work_dir, recursive = TRUE)
   on.exit(unlink(work_dir, recursive = TRUE), add = TRUE)
 
   local <- certificated_staff_local_file(end_year, work_dir)

--- a/man/certificated_staff_local_file.Rd
+++ b/man/certificated_staff_local_file.Rd
@@ -4,12 +4,19 @@
 \alias{certificated_staff_local_file}
 \title{Download (and, if zipped, extract) the certificated-staff data file}
 \usage{
-certificated_staff_local_file(end_year, work_dir)
+certificated_staff_local_file(
+  end_year,
+  work_dir,
+  download_fn = downloader::download
+)
 }
 \arguments{
 \item{end_year}{A covered school year end.}
 
 \item{work_dir}{A scratch directory the caller owns and cleans up.}
+
+\item{download_fn}{Download function with the same arguments used by
+\code{downloader::download}. Exposed for deterministic offline testing.}
 }
 \value{
 A list with \code{path}, \code{era}.

--- a/tests/testthat/test-fetch-staff-doedata.R
+++ b/tests/testthat/test-fetch-staff-doedata.R
@@ -70,6 +70,28 @@ test_that("fetch_certificated_staff rejects uncovered years and bad level", {
                "level must be")
 })
 
+test_that("legacy certificated-staff ZIP archives are validated as ZIPs", {
+  source_dir <- withr::local_tempdir()
+  source_csv <- file.path(source_dir, "cert.csv")
+  source_zip <- file.path(source_dir, "cert.zip")
+  writeLines("source-owned,data", source_csv)
+  zip::zipr(source_zip, source_csv, include_directories = FALSE)
+
+  work_dir <- withr::local_tempdir()
+  copy_download <- function(url, destfile, mode) {
+    file.copy(source_zip, destfile)
+  }
+  local <- certificated_staff_local_file(
+    2000,
+    work_dir,
+    download_fn = copy_download
+  )
+
+  expect_identical(local$era, "legacy")
+  expect_identical(basename(local$path), "cert.csv")
+  expect_identical(readLines(local$path), "source-owned,data")
+})
+
 
 # ==============================================================================
 # Suppression coercion (pure, no network) -- the load-bearing data-integrity test

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -226,9 +226,9 @@ districts <- directory$entities[directory$entities$entity_type == "district", ]
 # were a real zero)
 directory$meta$source_status
 
-# Compatibility data-frame views are also available for existing callers:
-schools_legacy <- get_school_directory()
-districts_legacy <- get_district_directory()
+# Existing callers can use the compatibility data-frame front doors
+# get_school_directory() and get_district_directory(). They make separate live
+# requests, so this vignette does not call them again after fetch_directory().
 
 # View available columns
 names(schools)

--- a/vignettes/nj-finance.Rmd
+++ b/vignettes/nj-finance.Rmd
@@ -63,8 +63,16 @@ identifier (`nces_dist`) is attached as a join key only.
 ```{r fetch-finance, cache=TRUE}
 # the spending side is published a year in arrears, so even years 2016-2024
 # give a clean statewide actuals series; 2024 is the latest full cross-section.
-fin_multi <- fetch_finance_multi(c(2016, 2018, 2020, 2022, 2024))
+fin_multi <- fetch_finance_multi(
+  c(2016, 2018, 2020, 2022, 2024),
+  allow_partial = TRUE
+)
 fin_2024  <- fetch_finance(2024)
+
+# Spending is complete for every requested year. The source ledger also makes
+# the unavailable 2020 and 2022 state-aid components explicit.
+get_source_results(fin_multi) %>%
+  select(end_year, component, source_status)
 ```
 
 ## Story 1: New Jersey per-pupil spending climbed 47% in eight years


### PR DESCRIPTION
## Summary

- avoid duplicate live directory requests in the getting-started vignette
- retain complete finance spending series while reporting unavailable state-aid components explicitly
- validate legacy certificated-staff archives as ZIP files and cover the behavior offline

## Local verification

- `devtools::check()` — 0 errors, 0 warnings; 4 pre-existing notes
- full `pkgdown::build_site_github_pages()` — passed
- Python tests — 38 passed, 38 live-gated skips
- staff regression tests — 27 passed, 10 live-gated skips